### PR TITLE
feat(KONFLUX-2742) add a file upload function

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM docker.io/snyk/snyk:linux@sha256:c7f21c3d71f64d592e427e78d5043375c9b93e304f70fdbbd8ca7306cbb0ba1f as snyk
 FROM quay.io/enterprise-contract/ec-cli:snapshot@sha256:141a7cd25ce0d098b1e40fd75d6f75873f8709c5f96f6340993b269c56e3f387 AS ec-cli
 FROM gcr.io/projectsigstore/cosign:v1.13.6@sha256:366bf5a7e882e9748e2b05f620258f8eab89ef4e3597001279291a88486c4fdf as cosign-bin
+#FROM quay.io/konflux-ci/oras:latest as oras
+FROM quay.io/redhat-user-workloads/ralphjbean-tenant/oras/oras:f281406da00d033e9f99a4d2010a66b69257972e as oras
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3-1612
 
 # Note that the version of OPA used by pr-checks must be updated manually to reflect conftest updates
@@ -50,6 +52,7 @@ COPY --from=ec-cli /usr/bin/ec /usr/local/bin/ec
 
 COPY --from=cosign-bin /ko-app/cosign /usr/local/bin/cosign
 
+COPY --from=oras /usr/bin/oras /usr/local/bin/oras
 
 COPY policies $POLICY_PATH
 COPY test/conftest.sh $POLICY_PATH

--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -31,6 +31,15 @@ setup() {
         fi
     }
 
+    oras() {
+        if [[ $1 == "push" && $2 == "--no-tty" && $3 == "valid-image-manifest-url:sha256-826def60fd1aa34f5090c9db60016773d91ecc324304d0ac3b01d.sarif" && $4 == "unittests_bash/data/sarif_successes.json:application/sarif+json" ]]; then
+            echo 'Pushed [registry] valid-image-manifest-url:sha256-826def60fd1aa34f5090c9db60016773d91ecc324304d0ac3b01d.sarif'
+            echo 'Digest: sha256:826def60fd1aa34f5090c9db60016773d91ecc324304d0ac3b01d'
+        else
+            echo 'Unrecognized call to mock oras'
+            return 1
+        fi
+    }
 }
 
 @test "Result: missing result" {
@@ -111,6 +120,14 @@ setup() {
     parse_test_output testname sarif unittests_bash/data/sarif_failures.json
     EXPECTED_JSON='{"result":"FAILURE","timestamp":"whatever","note":"For details, check Tekton task log.","namespace":"default","successes":0,"failures":1,"warnings":0}'
     test_json_eq "${EXPECTED_JSON}" "${TEST_OUTPUT}"
+}
+
+@test "ORAS upload: sarif file" {
+    TEST_OUTPUT=$(upload_file valid-image-manifest-url application/sarif+json sarif unittests_bash/data/sarif_successes.json)
+    EXPECTED_OUTPUT='Pushed [registry] valid-image-manifest-url:sha256-826def60fd1aa34f5090c9db60016773d91ecc324304d0ac3b01d.sarif
+Digest: sha256:826def60fd1aa34f5090c9db60016773d91ecc324304d0ac3b01d'
+    /usr/bin/diff -u <(echo "$TEST_OUTPUT") <(echo "$EXPECTED_OUTPUT")
+    [[ "${EXPECTED_OUTPUT}" = "${TEST_OUTPUT}" ]]
 }
 
 @test "Get Image Index Manifests: missing IMAGE_URL" {


### PR DESCRIPTION
The intent is to use this in the snyk sast task to upload the sarif result to the registry for later post-processing by other systems.