### PR TITLE
fix(release): explicitly specify token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,5 +38,6 @@ jobs:
       uses: ncipollo/release-action@v1.14.0
       with:
         tag: ${{ steps.tag_version.outputs.new_tag }}
+        token: ${{ secrets.KONFLUX_TEST_GITHUB_TOKEN }}
         name: ${{ steps.tag_version.outputs.new_tag }}
         body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
Default github token is used for action. We need token with higher privileges and rather than modify default token, let's explicitly set token.