### PR TITLE
feat(STONEINTG-659): task TEST_OUTPUT returns RFC3339 date format

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -64,7 +64,7 @@ make_result_json() {
 
   # Generate mandatory fields
   OUTPUT=$(jq -rce \
-    --arg date "$(date +%s)" \
+    --arg date "$(date -u --iso-8601=seconds)" \
     --arg result "${RESULT}" \
     --arg note "${NOTE}" \
     --arg namespace "${NAMESPACE}" \


### PR DESCRIPTION
Update make_result_json function to implement timestamp in RFC3339 date format to comply with ADR-30.
Example output of updated call to date: `2024-06-10T15:36:05+00:00`