### PR TITLE
feat: Added csdiff and git packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.
     python3 \
     clamav \
     clamd \
+    csdiff \
+    git \
     python3-pip \
     clamav-update && \
     pip3 install --no-cache-dir yq && \


### PR DESCRIPTION
csdiff and git packages are installed in order to be used by SAST tasks to parse the results and generate fingerprinting.

This will be used by future SAST tasks provided by the OpenScanHub team, for example: https://issues.redhat.com/browse/OSH-737
