### PR TITLE
feat: added python3-file-magic package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.
     clamd \
     csdiff \
     git \
+    python3-file-magic \
     python3-pip \
     clamav-update && \
     pip3 install --no-cache-dir yq && \


### PR DESCRIPTION
python3-file-magic package is installed in order to be used 
by SAST tasks to run find-unicode-control tool

Signed-off-by: Chuntao Han <chhan@redhat.com>