### PR TITLE
feat(Dockerfile): add ShellCheck/csmock-plugin-shellcheck for sast scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.
     git \
     python3-file-magic \
     python3-pip \
+    ShellCheck \
+    csmock-plugin-shellcheck-core \
     clamav-update && \
     pip3 install --no-cache-dir yq && \
     curl -s -L https://github.com/CycloneDX/sbom-utility/releases/download/v"${sbom_utility_version}"/sbom-utility-v"${sbom_utility_version}"-linux-amd64.tar.gz --output sbom-utility.tar.gz && \


### PR DESCRIPTION
csmock-plugin-shellcheck provides script to run shellcheck on a directory tree, which will be needed in the sast-shell-check task

Related jira issue: https://issues.redhat.com/browse/OSH-738