### PR TITLE
chore(Dockerfile): switch cosign registry from GCR to GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Container image that runs your code
 FROM docker.io/snyk/snyk:linux@sha256:6e10694887b4b1aad61adeb20c5474ba07337a71d6fc8f4ec367417d89e6526c as snyk
 FROM quay.io/enterprise-contract/ec-cli:snapshot@sha256:dc7d404596385e7d3c624ec0492524a1d57efe2b0c10cf0ec2158d49c0290a83 AS ec-cli
-FROM gcr.io/projectsigstore/cosign:v2.4.0@sha256:9d50ceb15f023eda8f58032849eedc0216236d2e2f4cfe1cdf97c00ae7798cfe as cosign-bin
+FROM ghcr.io/sigstore/cosign/cosign:v2.4.0@sha256:9d50ceb15f023eda8f58032849eedc0216236d2e2f4cfe1cdf97c00ae7798cfe as cosign-bin
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227.1726694542
 
 # Note that the version of OPA used by pr-checks must be updated manually to reflect conftest updates


### PR DESCRIPTION
This changes the Dockerfile to pull the cosign container image from GHCR instead of Google Cloud. This helps the Sigstore team manage their cloud spend (as GHCR is provided for free and Google Cloud Artifact Registry is not).

Note the container hash does not change and images are posted to both locations upon cosign's release process.