### PR TITLE
feat(STONEINTG-947): migrating clamav-db to konflux-ci in quay

### DIFF
--- a/.github/workflows/clam-db.yaml
+++ b/.github/workflows/clam-db.yaml
@@ -79,3 +79,12 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
           registry: ${{ env.REGISTRY }}
+
+      - name: Push into registry konflux-ci/clamav-db # temporarily added step to push to quay.io/konflux-ci/clamav-db 
+        if: ${{ github.event_name != 'pull_request' }}  
+        id: push-to-quay-konflux-ci
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/konflux-ci/clamav-db


### PR DESCRIPTION
this PR is part of the effort to migrate  quay repo  to konflux-ci/clamav-db ,  on this step we add the new repo 
so the clamav-db images will be pushed for both repos, once we see it works as expected then the old one will be decoupled

[STONEINTG-947](https://issues.redhat.com/browse/STONEINTG-947) 