### PR TITLE
feat(CVP-4340): add function to get unreleased bundles in utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227.1726694542
 ARG conftest_version=0.45.0
 ARG BATS_VERSION=1.6.0
 ARG sbom_utility_version=0.12.0
-ARG OPM_VERSION=v1.26.3
+ARG OPM_VERSION=v1.40.0
 ARG UMOCI_VERSION=v0.4.7
 
 ENV POLICY_PATH="/project"

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -227,3 +227,134 @@ get_image_manifests() {
   echo "${image_manifests}"
 
 }
+
+# This function will be used by tekton tasks in build-definitions
+# It returns the ocp_version targeted by the FBC fragment
+get_ocp_version_from_fbc_fragment() {
+  local FBC_FRAGMENT="$1"
+
+  if [ -z "$FBC_FRAGMENT" ]; then
+    echo "Missing FBC_FRAGMENT parameter" >&2
+    exit 2
+  fi
+
+  #Get target ocp version from the fragment
+  local ocp_version
+  if ! ocp_version=$(skopeo inspect --no-tags --raw docker://"$FBC_FRAGMENT"); then
+    echo "Could not inspect image $FBC_FRAGMENT"
+    exit 1
+  fi
+
+  ocp_version=$(echo "$ocp_version" |  jq -r '.annotations."org.opencontainers.image.base.name"' | sed -e "s/@.*$//" -e "s/^.*://")
+  echo "$ocp_version"
+}
+
+# Given output of `opm render` command and package name, this function returns
+# all unique bundles for the given package in the catalog
+extract_unique_bundles_from_catalog() {
+  local RENDER_OUT="$1"
+  local PACKAGE_NAME="$2"
+
+  if [ -z "$RENDER_OUT" ]; then
+    echo "Missing 'opm render' output for the image" >&2
+    exit 2
+  fi
+
+  if [ -z "$PACKAGE_NAME" ]; then
+    echo "Missing package name" >&2
+    exit 2
+  fi
+
+  # Jq query to extract unique bundles from `opm render` command output
+  local jq_unique_bundles='select( .package == "'$PACKAGE_NAME'" ) | select(.schema == "olm.bundle") | select( [.properties[]|select(.type == "olm.deprecated")] == []) | "\(.image)"'
+  echo "$RENDER_OUT" | jq -r "$jq_unique_bundles"
+}
+
+# Given output of `opm render` command and package name, this function returns
+# unique package names in the catalog
+extract_unique_package_names_from_catalog() {
+  local RENDER_OUT="$1"
+
+  if [ -z "$RENDER_OUT" ]; then
+    echo "Missing 'opm render' output for the image" >&2
+    exit 2
+  fi
+
+  echo "$render_out_fbc" | jq -r 'select(.schema == "olm.package") | .name'
+}
+
+# This function will be used by tekton tasks in build-definitions
+# It returns a list of unreleased bundles in the FBC fragment by comparing it with
+# the corresponding production index image
+get_unreleased_bundle() {
+  # FBC fragment containing the unreleased bundle
+  local FBC_FRAGMENT=""
+  local INDEX_IMAGE="registry.redhat.io/redhat/redhat-operator-index"
+
+  get_unreleased_bundle_usage()
+  {
+    echo "
+  get_unreleased_bundle  -i FBC_FRAGMENT [-b INDEX_IMAGE]
+  " >&2
+    exit 2
+  }
+
+  local opt
+  while getopts "i:b:" opt; do
+      case "${opt}" in
+          i)
+              FBC_FRAGMENT="${OPTARG}" ;;
+          b)
+              INDEX_IMAGE="${OPTARG}" ;;
+          *)
+              get_unreleased_bundle_usage ;;
+      esac
+  done
+
+  if [ -z "$FBC_FRAGMENT" ]; then
+    echo "Missing parameter FBC_FRAGMENT" >&2
+    exit 2
+  fi
+
+  # If the index image is provided and has a tag, remove it.
+  # The target ocp version is determined from the fragment
+  if [[ "$INDEX_IMAGE" == *:* ]]; then
+    INDEX_IMAGE="${INDEX_IMAGE%%:*}"
+  fi
+
+  #Get target ocp version from the fragment
+  local ocp_version
+  if ! ocp_version=$(get_ocp_version_from_fbc_fragment "$FBC_FRAGMENT"); then
+    echo "Could not get ocp version for the fragment" >&2
+    exit 1
+  fi
+
+  # Run opm render on the FBC fragment to extract package names
+  local render_out_fbc unique_bundles_fbc package_names
+  if ! render_out_fbc=$(opm render "$FBC_FRAGMENT"); then
+    echo "Could not render image $FBC_FRAGMENT" >&2
+    exit 1
+  fi
+  package_names=$(extract_unique_package_names_from_catalog "$render_out_fbc")
+
+  # Run opm render on the index image
+  local render_out_index unique_bundles_index tagged_index
+  tagged_index="${INDEX_IMAGE}:${ocp_version}"
+  if ! render_out_index=$(opm render "$tagged_index"); then
+    echo "Could not render image $tagged_index" >&2
+    exit 1
+  fi
+
+  # Get unique bundles for each package from the fragment and the index
+  for package_name in $package_names; do
+    unique_bundles_fbc+="$(extract_unique_bundles_from_catalog "$render_out_fbc" "$package_name")"$'\n'
+    unique_bundles_index+="$(extract_unique_bundles_from_catalog "$render_out_index" "$package_name")"$'\n'
+  done
+
+  # Compare the bundle lists and return the diff
+  local unreleased_bundles
+  unreleased_bundles=$(diff <(echo "$unique_bundles_fbc") <(echo "$unique_bundles_index") | grep '^<' | sed 's/^< //' | tr '\n' ' ')
+
+  echo "${unreleased_bundles}" | tr ' ' '\n'
+
+}


### PR DESCRIPTION
Operator tests require the functionality to extract unreleased bundle image from FBC fragments. This commit adds a function that can be reused in multiple tekton tasks