### PR TITLE
fix(CVP-4340): handle control chars in OPM output

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -267,7 +267,7 @@ extract_unique_bundles_from_catalog() {
 
   # Jq query to extract unique bundles from `opm render` command output
   local jq_unique_bundles='select( .package == "'$PACKAGE_NAME'" ) | select(.schema == "olm.bundle") | select( [.properties[]|select(.type == "olm.deprecated")] == []) | "\(.image)"'
-  echo "$RENDER_OUT" | jq -r "$jq_unique_bundles"
+  echo "$RENDER_OUT" | tr -d '\000-\031' | jq -r "$jq_unique_bundles"
 }
 
 # Given output of `opm render` command and package name, this function returns
@@ -280,7 +280,7 @@ extract_unique_package_names_from_catalog() {
     exit 2
   fi
 
-  echo "$render_out_fbc" | jq -r 'select(.schema == "olm.package") | .name'
+  echo "$RENDER_OUT" | tr -d '\000-\031' | jq -r 'select(.schema == "olm.package") | .name'
 }
 
 # This function will be used by tekton tasks in build-definitions

--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -42,7 +42,7 @@ setup() {
 
     opm() {
         if [[ $1 == "render" && $2 == "valid-fragment-fbc" || $1 == "render" && $2 == "valid-fragment-fbc-success" || $1 == "render" && $2 == "valid-fragment-fbc-success-2" ]]; then
-            echo '{"schema": "olm.package", "name": "rhbk-operator"}{"schema": "olm.bundle", "package": "rhbk-operator", "image": "registry.redhat.io/rhbk/keycloak-operator-bundle@my-sha", "properties":[]}{"schema": "olm.package", "name": "not-rhbk-operator"}{"schema": "olm.bundle", "package": "not-rhbk-operator", "image": "registry.redhat.io/not-rhbk/operator-bundle@my-other-sha", "properties":[]}'
+            echo '{"invalid-control-char": "This is an invalid control char \\t", "schema": "olm.package", "name": "rhbk-operator"}{"schema": "olm.bundle", "package": "rhbk-operator", "image": "registry.redhat.io/rhbk/keycloak-operator-bundle@my-sha", "properties":[]}{"schema": "olm.package", "name": "not-rhbk-operator"}{"schema": "olm.bundle", "package": "not-rhbk-operator", "image": "registry.redhat.io/not-rhbk/operator-bundle@my-other-sha", "properties":[]}'
             return 0
         elif [[ $1 == "render" && $2 == "registry.redhat.io/redhat/redhat-operator-index:v4.15" ]]; then
             echo '{"schema": "olm.package", "name": "rhbk-operator"}{"schema": "olm.bundle", "package": "rhbk-operator", "image": "registry.redhat.io/rhbk/keycloak-operator-bundle@random-image", "properties":[]}{"schema": "olm.package", "name": "not-rhbk-operator"}{"schema": "olm.bundle", "package": "not-rhbk-operator", "image": "registry.redhat.io/not-rhbk/operator-bundle@not-my-other-sha", "properties":[]}'
@@ -209,6 +209,5 @@ setup() {
 @test "Get Unreleased Bundle: valid-fragment-fbc-success-2 and custom index" {
     run get_unreleased_bundle -i valid-fragment-fbc-success-2 -b registry.io/random-index:v4.20
     EXPECTED_RESPONSE="registry.redhat.io/rhbk/keycloak-operator-bundle@my-sha"
-    echo ${output}
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }


### PR DESCRIPTION
for some fragments and index images, the output of opm render command contains control characters when stored in a bash variable. This commit fixes that by cleaning the output before running jq on it