### PR TITLE
fix(CVP-4331): install golang to bypass check-payload bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN rpm -Uvh epel-release-latest-9.noarch.rpm && \
     clamd \
     csdiff \
     git \
+    # Remove golang after https://github.com/openshift/check-payload/issues/231 is resolved
+    golang \
     python3-file-magic \
     python3-pip \
     ShellCheck \


### PR DESCRIPTION
found a bug in check-payload where the binary doesn't work correctly if golang isn't installed during runtime. We can revert this commit once the bug is resolved