### PR TITLE
feat: expanding the functionality of utils.sh and combining functions

### DIFF
--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -2,6 +2,7 @@
 
 setup() {
     source test/utils.sh
+    OPM_RENDER_CACHE=$(mktemp -d)
 
     DEBUG=0
 
@@ -17,29 +18,51 @@ setup() {
     }
 
     skopeo() {
-        if [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://valid-url" ]]; then
-            echo '{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:f3d43a4e4e5371c9d972fa6a17144be940ddf3a3fd9185e2a4149a4c20e51e55","size":928,"platform":{"architecture":"amd64","os":"linux"}},{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:8e8229030a72efe300422eca38af80fae9b166361ae0f3ede8fb2fdad987f38f","size":928,"platform":{"architecture":"arm64","os":"linux"}}]}'
-            return 0
-        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "docker://valid-image-manifest-url" ]]; then
-            echo '{"Architecture": "arm64", "Digest": "sha256:826def60fd1aa34f5090c9db60016773d91ecc324304d0ac3b01d"}'
-            return 0
-        elif [[ $1 == "inspect" && $2 == "--config" && $3 == "docker://valid-image-manifest-url-2" ]]; then
-            echo '{"config": {"Labels": {"architecture":"arm64"}}}'
-            return 0
-        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://valid-image-manifest-url" || $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://invalid-image-manifest-url"  ]]; then
-            echo '{"schemaVersion": 2,"mediaType": "application/vnd.oci.image.manifest.v1+json","config": {"mediaType": "application/vnd.oci.image.config.v1+json","digest": "sha256:826def60fd1aa34f5090c9db60016773d91ecc324304d0ac3b01d","size": 14208}}'
-        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://invalid-fragment-fbc" || $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://valid-fragment-fbc" ]]; then
-            echo '{"annotations": {"org.opencontainers.image.base.name": "registry.redhat.io/openshift4/ose-operator-registry:v4.12"}}'
-            return 0
-        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://valid-fragment-fbc-success" ]]; then
-            echo '{"annotations": {"org.opencontainers.image.base.name": "registry.redhat.io/openshift4/ose-operator-registry:v4.15"}}'
-            return 0
-        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://valid-fragment-fbc-success-2" ]]; then
-            echo '{"annotations": {"org.opencontainers.image.base.name": "registry.redhat.io/openshift4/ose-operator-registry:v4.20"}}'
-            return 0
-        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://valid-fbc-fragment-isolated" ]]; then
-            echo '{"annotations": {"org.opencontainers.image.base.name": "registry.redhat.io/openshift4/ose-operator-registry:v4.15"}}'
-            return 0
+        # The --raw inspects return the OCI metadata for the image references. This includes the mediaType, manifests (for image indexes),
+        # digests and their platforms, and annotations.
+        # The non-raw skopeo inspect returns information about the image. This is primarily used to get the digest and architecture of an image from its OCI Image Manifest.
+
+        # registry/image@valid-url
+        if [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://registry/image@valid-url" ]]; then
+            echo '{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"valid-manifest-amd64","size":928,"platform":{"architecture":"amd64","os":"linux"}},{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"valid-manifest-arm64","size":928,"platform":{"architecture":"arm64","os":"linux"}}]}'
+
+        # registry/image@valid-manifest-amd64
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "docker://registry/image@valid-manifest-amd64" || $1 == "inspect" && $2 == "--no-tags" && $3 == "docker://registry/fbc-fragment@invalid" || $1 == "inspect" && $2 == "--no-tags" && $3 == "docker://registry/fbc-fragment@valid-manifest-amd64" ]]; then
+            echo '{"Name": "valid-manifest-amd64", "Architecture": "amd64", "Labels": {"architecture":"arm64", "name": "my-image"}, "Digest": "valid-manifest-amd64", "Os": "linux"}'
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://registry/image@valid-manifest-amd64" || $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://registry/fbc-fragment@invalid" || $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://registry/fbc-fragment@valid-manifest-amd64" ]]; then
+            echo '{"schemaVersion": 2,"mediaType": "application/vnd.oci.image.manifest.v1+json","config": {"mediaType": "application/vnd.oci.image.config.v1+json","digest": "valid-manifest-amd64","size": 14208},"annotations": {"org.opencontainers.image.base.name": "registry.redhat.io/openshift4/ose-operator-registry:v4.12"}}'
+
+        # registry/image-manifest@valid-labels
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "docker://registry/image-manifest@valid-labels" ]]; then
+            echo '{"Name": "valid-labels", "Architecture": "amd64", "Labels": {"architecture":"arm64", "name": "my-image"}, "Digest": "valid-labels", "Os": "linux"}'
+
+        # registry/image-manifest@valid
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://registry/image-manifest@valid" || $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://registry/image-manifest@invalid" ]]; then
+            echo '{"schemaVersion": 2,"mediaType": "application/vnd.oci.image.manifest.v1+json","config": {"mediaType": "application/vnd.oci.image.config.v1+json","digest": "valid-manifest-amd64","size": 14208}}'
+        
+        # registry/image-manifest@valid-oci
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://registry/image-manifest@valid-oci" || $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://registry/image-manifest@valid-oci" ]]; then
+            echo '{"schemaVersion": 2,"mediaType": "application/vnd.oci.image.manifest.v1+json","config": {"mediaType": "application/vnd.oci.image.config.v1+json","digest": "valid-manifest-amd64","size": 14208}}'
+
+        # registry/fbc-fragment@valid-success
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "docker://registry/fbc-fragment@valid-success" ]]; then
+            echo '{"Name": "valid-success", "Architecture": "amd64", "Labels": {"architecture":"arm64", "name": "my-image"}, "Digest": "valid-success", "Os": "linux"}'
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://registry/fbc-fragment@valid-success" ]]; then
+            echo '{"schemaVersion": 2,"mediaType": "application/vnd.oci.image.manifest.v1+json","config": {"mediaType": "application/vnd.oci.image.config.v1+json","digest": "valid-success","size": 14208},"annotations": {"org.opencontainers.image.base.name": "registry.redhat.io/openshift4/ose-operator-registry:v4.15", "org.opencontainers.image.base.digest": "boo"}}'
+
+        # registry/fbc-fragment@valid-success-2
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "docker://registry/fbc-fragment@valid-success-2" ]]; then
+            echo '{"Name": "valid-success-2", "Architecture": "amd64", "Labels": {"architecture":"arm64", "name": "my-image"}, "Digest": "valid-success-2", "Os": "linux"}'
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://registry/fbc-fragment@valid-success-2" ]]; then
+            echo '{"schemaVersion": 2,"mediaType": "application/vnd.oci.image.manifest.v1+json","config": {"mediaType": "application/vnd.oci.image.config.v1+json","digest": "valid-success-2","size": 14208},"annotations": {"org.opencontainers.image.base.name": "registry.redhat.io/openshift4/ose-operator-registry:v4.20"}}'
+
+        # registry/fbc-fragment@isolated
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "docker://registry/fbc-fragment@isolated" ]]; then
+            echo '{"Name": "isolated", "Architecture": "amd64", "Labels": {"architecture":"arm64", "name": "my-image"}, "Digest": "isolated", "Os": "linux"}'
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://registry/fbc-fragment@isolated" ]]; then
+            echo '{"schemaVersion": 2,"mediaType": "application/vnd.oci.image.manifest.v1+json","config": {"mediaType": "application/vnd.oci.image.config.v1+json","digest": "isolated","size": 14208},"annotations": {"org.opencontainers.image.base.name": "registry.redhat.io/openshift4/ose-operator-registry:v4.15"}}'
+        
+        # Some skopeo commands fail
         else
             echo 'Unrecognized call to mock skopeo'
             return 1
@@ -47,10 +70,10 @@ setup() {
     }
 
     opm() {
-        if [[ $1 == "render" && $2 == "valid-fragment-fbc" || $1 == "render" && $2 == "valid-fragment-fbc-success" || $1 == "render" && $2 == "valid-fragment-fbc-success-2" ]]; then
+        if [[ $1 == "render" && $2 == "registry/fbc-fragment:tag@valid-manifest-amd64" || $1 == "render" && $2 == "registry/fbc-fragment:tag@valid-success" || $1 == "render" && $2 == "registry/fbc-fragment:tag@valid-success-2" ]]; then
             echo '{"invalid-control-char": "This is an invalid control char \\t", "schema": "olm.package", "name": "rhbk-operator"}{"schema": "olm.bundle", "package": "rhbk-operator", "image": "registry.redhat.io/rhbk/keycloak-operator-bundle@my-sha", "properties":[], "relatedImages": [{"name": "foo-bar", "image": "registry.redhat.io/foo/bar@sha256:my-bar-sha"}, {"name": "foo-baz", "image": "registry.redhat.io/foo/baz@sha256:my-sha"}]}{"schema": "olm.package", "name": "not-rhbk-operator"}{"schema": "olm.bundle", "package": "not-rhbk-operator", "image": "registry.redhat.io/not-rhbk/operator-bundle@my-other-sha", "properties":[], "relatedImages": [{"name": "foo-baz", "image": "registry.redhat.io/foo/baz@sha256:my-sha"}]}'
             return 0
-        elif [[ $1 == "render" && $2 == "valid-fbc-fragment-isolated" ]]; then
+        elif [[ $1 == "render" && $2 == "registry/fbc-fragment:tag@isolated" ]]; then
             echo '{"invalid-control-char": "This is an invalid control char \\t", "schema": "olm.package", "name": "rhbk-operator"}{"schema": "olm.bundle", "package": "rhbk-operator", "image": "registry.redhat.io/rhbk/keycloak-operator-bundle@my-sha", "properties":[], "relatedImages": [{"name": "foo-bar", "image": "registry.redhat.io/foo/bar@sha256:my-bar-sha"}, {"name": "foo-baz", "image": "registry.redhat.io/foo/baz@sha256:my-sha"}]}'
         elif [[ $1 == "render" && $2 == "valid-operator-bundle-1" ]]; then
             echo '{"schema":"olm.bundle", "relatedImages": [{"name": "", "image": "quay.io/securesign/rhtas-operator:something"}]}'
@@ -71,7 +94,10 @@ setup() {
             return 1
         fi
     }
+}
 
+teardown() {
+    rm -rf $OPM_RENDER_CACHE
 }
 
 @test "Result: missing result" {
@@ -154,134 +180,276 @@ setup() {
     test_json_eq "${EXPECTED_JSON}" "${TEST_OUTPUT}"
 }
 
+@test "Parse image url: missing parameter" {
+    run parse_image_url
+    EXPECTED_RESPONSE="parse_image_url: Missing positional parameter \$1 (image url)"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 2 ]]
+}
+
+@test "Parse image url: multiple at" {
+    run parse_image_url foo@sha@sha
+    EXPECTED_RESPONSE='parse_image_url: foo@sha@sha does not match the format registry(:port)/repository(:tag)(@digest)'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 3 ]]
+}
+
+@test "Parse image url: multiple tags" {
+    run parse_image_url registry:port/foo:bar:bar
+    EXPECTED_RESPONSE='parse_image_url: registry:port/foo:bar:bar does not match the format registry(:port)/repository(:tag)(@digest)'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 3 ]]
+}
+
+@test "Get image repository: repository" {
+    run get_image_registry_and_repository foo
+    EXPECTED_RESPONSE='foo'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository: repository, tag, and digest" {
+    run get_image_registry_and_repository foo:bar@digest
+    EXPECTED_RESPONSE='foo'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository and tag: repository" {
+    run get_image_registry_repository_tag foo
+    EXPECTED_RESPONSE='foo'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository and tag: repository and tag" {
+    run get_image_registry_repository_tag foo:bar
+    EXPECTED_RESPONSE='foo:bar'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository and tag: repository and digest" {
+    run get_image_registry_repository_tag foo@digest
+    EXPECTED_RESPONSE='foo'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository and tag: repository, tag, and digest" {
+    run get_image_registry_repository_tag foo:bar@digest
+    EXPECTED_RESPONSE='foo:bar'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository and digest: repository" {
+    run get_image_registry_repository_digest foo
+    EXPECTED_RESPONSE='foo'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository and digest: repository and tag" {
+    run get_image_registry_repository_digest foo:bar
+    EXPECTED_RESPONSE='foo'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository and digest: repository and digest" {
+    run get_image_registry_repository_digest foo@digest
+    EXPECTED_RESPONSE='foo@digest'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository and digest: repository, tag, and digest" {
+    run get_image_registry_repository_digest foo:bar@digest
+    EXPECTED_RESPONSE='foo@digest'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository, tag, and digest: repository" {
+    run get_image_registry_repository_tag_digest foo
+    EXPECTED_RESPONSE='foo'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository, tag, and digest: repository and tag" {
+    run get_image_registry_repository_tag_digest foo:bar
+    EXPECTED_RESPONSE='foo:bar'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository, tag, and digest: repository and digest" {
+    run get_image_registry_repository_tag_digest foo@digest
+    EXPECTED_RESPONSE='foo@digest'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get image repository, tag, and digest: repository, tag, and digest" {
+    run get_image_registry_repository_tag_digest foo:bar@digest
+    EXPECTED_RESPONSE='foo:bar@digest'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get base image: registry/image@valid-url" {
+    run get_base_image registry/image@valid-url
+    EXPECTED_RESPONSE='registry.redhat.io/openshift4/ose-operator-registry:v4.12'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get base image: registry/fbc-fragment@valid-success" {
+    run get_base_image registry/fbc-fragment@valid-success
+    EXPECTED_RESPONSE='registry.redhat.io/openshift4/ose-operator-registry:v4.15@boo'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get OCP version from fragment: registry/fbc-fragment@valid-success" {
+    run get_ocp_version_from_fbc_fragment registry/fbc-fragment@valid-success
+    EXPECTED_RESPONSE='v4.15'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get matching catalog image from fragment: registry/fbc-fragment@valid-success" {
+    run get_target_fbc_catalog_image -i registry/fbc-fragment@valid-success -b registry.redhat.io/openshift4/ose-operator-registry
+    EXPECTED_RESPONSE='registry.redhat.io/openshift4/ose-operator-registry:v4.15'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get matching catalog image from fragment: registry/fbc-fragment@valid-success default index" {
+    run get_target_fbc_catalog_image -i registry/fbc-fragment@valid-success
+    EXPECTED_RESPONSE='registry.redhat.io/redhat/redhat-operator-index:v4.15'
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
 @test "Get Image Index Manifests: missing IMAGE_URL" {
     run get_image_manifests
     [ "$status" -eq 2 ]
 }
 
-@test "Get Image Index Manifests: invalid-url" {
-    run get_image_manifests -i invalid-url
-    EXPECTED_RESPONSE='The raw image inspect command failed'
+@test "Get Image Index Manifests: registry/image:tag@invalid-url" {
+    run get_image_manifests -i registry/image:tag@invalid-url
+    EXPECTED_RESPONSE='get_image_manifests: The raw image inspect command failed'
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }
 
 @test "Get Image Index Manifests: success with raw flag" {
-    run get_image_manifests -i valid-url
-    EXPECTED_RESPONSE='{"amd64":"sha256:f3d43a4e4e5371c9d972fa6a17144be940ddf3a3fd9185e2a4149a4c20e51e55","arm64":"sha256:8e8229030a72efe300422eca38af80fae9b166361ae0f3ede8fb2fdad987f38f"}'
+    run get_image_manifests -i registry/image:tag@valid-url
+    EXPECTED_RESPONSE='{"amd64":"valid-manifest-amd64","arm64":"valid-manifest-arm64"}'
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
 @test "Get Image Manifest Digest: success with raw flag" {
-    run get_image_manifests -i valid-image-manifest-url
-    EXPECTED_RESPONSE='{"arm64":"sha256:826def60fd1aa34f5090c9db60016773d91ecc324304d0ac3b01d"}'
+    run get_image_manifests -i registry/image:tag@valid-manifest-amd64
+    EXPECTED_RESPONSE='{"amd64":"valid-manifest-amd64"}'
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
-@test "Get Image Manifest Digest: invalid-image-manifest-url" {
-    run get_image_manifests -i invalid-image-manifest-url
-    EXPECTED_RESPONSE='The image manifest could not be inspected'
+@test "Get Image Manifest Digest: registry/image-manifest:tag@invalid" {
+    # This will pass the --raw inspection but will fail when the raw isn't used. It just checks the
+    # error case of the skopeo command not working. This check would not be likely to fail in use.
+    run get_image_manifests -i registry/image-manifest:tag@invalid
+    EXPECTED_RESPONSE='get_image_manifests: The image manifest could not be inspected'
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
+}
+
+@test "Get Image Manifest OCI: registry/image-manifest:tag@valid-oci" {
+    # This inspection passes but there is no architecture or digest when
+    # performing a non-raw inspect
+    run get_image_manifests -i registry/image-manifest:tag@valid-oci
+    EXPECTED_RESPONSE='get_image_manifests: The image manifest could not be inspected'
 }
 
 @test "Get Unreleased Bundle: missing FBC_FRAGMENT" {
-    run get_unreleased_bundle
-    EXPECTED_RESPONSE='Missing parameter FBC_FRAGMENT'
+    run get_unreleased_bundles
+    EXPECTED_RESPONSE="get_unreleased_bundles: missing keyword parameter (-i FBC_FRAGMENT)"
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 2 ]]
 }
 
-@test "Get Unreleased Bundle: invalid-url" {
-    run get_unreleased_bundle -i invalid-url
-    EXPECTED_RESPONSE='Could not get ocp version for the fragment'
+@test "Get Unreleased Bundle: registry/image:tag@valid-url" {
+    run get_unreleased_bundles -i registry/image:tag@valid-url
+    EXPECTED_RESPONSE=$(echo "render_opm: could not render catalog registry/image:tag@valid-url*extract_differential_fbc_metadata: could not render FBC fragment registry/image:tag@valid-url"  | tr '*' '\n')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }
 
-@test "Get Unreleased Bundle: invalid-fragment-fbc" {
-    run get_unreleased_bundle -i invalid-fragment-fbc
-    EXPECTED_RESPONSE='Could not render image invalid-fragment-fbc'
+@test "Get Unreleased Bundle: registry/fbc-fragment:tag@invalid" {
+    run get_unreleased_bundles -i registry/fbc-fragment:tag@invalid
+    EXPECTED_RESPONSE=$(echo "render_opm: could not render catalog registry/fbc-fragment:tag@invalid*extract_differential_fbc_metadata: could not render FBC fragment registry/fbc-fragment:tag@invalid"  | tr '*' '\n')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }
 
-@test "Get Unreleased Bundle: valid-fragment-fbc and invalid index" {
-    run get_unreleased_bundle -i valid-fragment-fbc
-    EXPECTED_RESPONSE='Could not render image registry.redhat.io/redhat/redhat-operator-index:v4.12'
+@test "Get Unreleased Bundle: valid FBC fragment and invalid index" {
+    run get_unreleased_bundles -i registry/fbc-fragment:tag@valid-manifest-amd64
+    EXPECTED_RESPONSE=$(echo "render_opm: could not render catalog registry.redhat.io/redhat/redhat-operator-index:v4.12*extract_differential_fbc_metadata: could not render index image registry.redhat.io/redhat/redhat-operator-index:v4.12"  | tr '*' '\n')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }
 
-@test "Get Unreleased Bundle: valid-fragment-fbc-success" {
-    run get_unreleased_bundle -i valid-fragment-fbc-success
+@test "Get Unreleased Bundle: registry/fbc-fragment:tag@valid-success" {
+    run get_unreleased_bundles -i registry/fbc-fragment:tag@valid-success
     EXPECTED_RESPONSE=$(echo "registry.redhat.io/rhbk/keycloak-operator-bundle@my-sha registry.redhat.io/not-rhbk/operator-bundle@my-other-sha"  | tr ' ' '\n')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
-@test "Get Unreleased Bundle: valid-fragment-fbc-success and index with tag" {
-    run get_unreleased_bundle -i valid-fragment-fbc-success -b registry.redhat.io/redhat/redhat-operator-index:v4.15@randomsha256
+@test "Get Unreleased Bundle: registry/fbc-fragment:tag@valid-success and index with tag" {
+    run get_unreleased_bundles -i registry/fbc-fragment:tag@valid-success -b registry.redhat.io/redhat/redhat-operator-index:v4.15@randomsha256
     EXPECTED_RESPONSE=$(echo "registry.redhat.io/rhbk/keycloak-operator-bundle@my-sha registry.redhat.io/not-rhbk/operator-bundle@my-other-sha"  | tr ' ' '\n')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
-@test "Get Unreleased Bundle: valid-fragment-fbc-success-2 and custom index" {
-    run get_unreleased_bundle -i valid-fragment-fbc-success-2 -b registry.io/random-index:v4.20
+@test "Get Unreleased Bundle: registry/fbc-fragment:tag@valid-success-2 and custom index" {
+    run get_unreleased_bundles -i registry/fbc-fragment:tag@valid-success-2 -b registry.io/random-index:v4.20
     EXPECTED_RESPONSE="registry.redhat.io/rhbk/keycloak-operator-bundle@my-sha"
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
 @test "Get Unreleased FBC related images: missing FBC_FRAGMENT" {
     run get_unreleased_fbc_related_images
-    EXPECTED_RESPONSE='Missing parameter FBC_FRAGMENT'
+    EXPECTED_RESPONSE='get_unreleased_fbc_related_images: missing keyword parameter (-i FBC_FRAGMENT)'
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 2 ]]
 }
 
-@test "Get Unreleased FBC related images: invalid-url" {
-    run get_unreleased_fbc_related_images -i invalid-url
-    EXPECTED_RESPONSE='Could not get ocp version for the fragment'
+@test "Get Unreleased FBC related images: registry/image:tag@invalid-url" {
+    run get_unreleased_fbc_related_images -i registry/image:tag@invalid-url
+    EXPECTED_RESPONSE=$(echo "render_opm: could not render catalog registry/image:tag@invalid-url*extract_differential_fbc_metadata: could not render FBC fragment registry/image:tag@invalid-url"  | tr '*' '\n')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }
 
-@test "Get Unreleased FBC related images: invalid-fragment-fbc" {
-    run get_unreleased_fbc_related_images -i invalid-fragment-fbc
-    EXPECTED_RESPONSE='Could not render image invalid-fragment-fbc'
+@test "Get Unreleased FBC related images: registry/fbc-fragment:tag@invalid" {
+    run get_unreleased_fbc_related_images -i registry/fbc-fragment:tag@invalid
+    EXPECTED_RESPONSE=$(echo "render_opm: could not render catalog registry/fbc-fragment:tag@invalid*extract_differential_fbc_metadata: could not render FBC fragment registry/fbc-fragment:tag@invalid"  | tr '*' '\n')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }
 
-@test "Get Unreleased FBC related images: valid-fragment-fbc and invalid index" {
-    run get_unreleased_fbc_related_images -i valid-fragment-fbc
-    EXPECTED_RESPONSE='Could not render image registry.redhat.io/redhat/redhat-operator-index:v4.12'
+@test "Get Unreleased FBC related images: registry/fbc-fragment:tag@valid-url and invalid index" {
+    run get_unreleased_fbc_related_images -i registry/fbc-fragment:tag@valid-url
+    EXPECTED_RESPONSE='get_unreleased_bundles: Could not render index image registry.redhat.io/redhat/redhat-operator-index:v4.12'
+    EXPECTED_RESPONSE=$(echo "render_opm: could not render catalog registry/fbc-fragment:tag@valid-url*extract_differential_fbc_metadata: could not render FBC fragment registry/fbc-fragment:tag@valid-url"  | tr '*' '\n')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }
 
-@test "Get Unreleased FBC related images: valid-fbc-fragment-isolated and missing index" {
-    run get_unreleased_fbc_related_images -i valid-fbc-fragment-isolated
+@test "Get Unreleased FBC related images: registry/fbc-fragment:tag@isolated and missing index" {
+    run get_unreleased_fbc_related_images -i registry/fbc-fragment:tag@isolated
     EXPECTED_RESPONSE=$(echo "[ **\"registry.redhat.io/foo/bar@sha256:my-bar-sha\" ]" | tr ' ' '\n' | tr '*' ' ')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
-@test "Get Unreleased FBC related images: valid-fbc-fragment-isolated and index with tag" {
-    run get_unreleased_fbc_related_images -i valid-fbc-fragment-isolated -b registry.redhat.io/redhat/redhat-operator-index:v4.15@randomsha256
+@test "Get Unreleased FBC related images: registry/fbc-fragment:tag@isolated and index with tag" {
+    run get_unreleased_fbc_related_images -i registry/fbc-fragment:tag@isolated -b registry.redhat.io/redhat/redhat-operator-index:v4.15@randomsha256
     EXPECTED_RESPONSE=$(echo "[ **\"registry.redhat.io/foo/bar@sha256:my-bar-sha\" ]" | tr ' ' '\n' | tr '*' ' ')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
-@test "Get Unreleased FBC related images: valid-fbc-fragment-isolated and custom index" {
-    run get_unreleased_fbc_related_images -i valid-fbc-fragment-isolated -b registry.io/random-index:v4.20
+@test "Get Unreleased FBC related images: registry/fbc-fragment:tag@isolated and custom index" {
+    run get_unreleased_fbc_related_images -i registry/fbc-fragment:tag@isolated -b registry.io/random-index:v4.20
     EXPECTED_RESPONSE="[]"
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
-@test "Get Image Labels: valid-image-manifest-url-2" {
-    run get_image_labels valid-image-manifest-url-2
-    EXPECTED_RESPONSE="architecture=arm64"
+@test "Get Image Labels: registry/image-manifest:tag@valid-labels" {
+    run get_image_labels registry/image-manifest:tag@valid-labels
+    EXPECTED_RESPONSE=$(echo "architecture=arm64 name=my-image" | tr ' ' '\n')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
 @test "Get Image Labels: missing image" {
     run get_image_labels
-    EXPECTED_RESPONSE="Missing image pull spec"
+    EXPECTED_RESPONSE="get_image_labels: missing positional parameter \$1 (image pull spec)"
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 2 ]]
 }
 
-@test "Get Image Labels: invalid-image-manifest-url" {
-    run get_image_labels invalid-image-manifest-url
-    EXPECTED_RESPONSE='Failed to inspect the image'
+@test "Get Image Labels: registry/image-manifest:tag@invalid" {
+    run get_image_labels registry/image-manifest:tag@invalid
+    EXPECTED_RESPONSE='get_image_labels: failed to inspect the image'
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }
 
@@ -293,13 +461,13 @@ setup() {
 
 @test "Get relatedImages from operator bundle: missing image" {
     run extract_related_images_from_bundle
-    EXPECTED_RESPONSE="Missing image pull spec"
+    EXPECTED_RESPONSE="extract_related_images_from_bundle: missing positional parameter \$1 (image pull spec)"
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 2 ]]
 }
 
-@test "Get relatedImages from operator bundle: invalid-fragment-fbc" {
-    run extract_related_images_from_bundle invalid-fragment-fbc
-    EXPECTED_RESPONSE='Failed to render the image'
+@test "Get relatedImages from operator bundle: registry/fbc-fragment:tag@invalid" {
+    run extract_related_images_from_bundle registry/fbc-fragment:tag@invalid
+    EXPECTED_RESPONSE=$(echo "render_opm: could not render catalog registry/fbc-fragment:tag@invalid*extract_related_images_from_bundle: failed to render the image registry/fbc-fragment:tag@invalid"  | tr '*' '\n')
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }
 
@@ -326,13 +494,13 @@ EOF
 
 @test "Process process_image_digest_mirror_set: invalid input" {
     run process_image_digest_mirror_set "\"invalid yaml"
-    EXPECTED_RESPONSE="Invalid YAML input"
+    EXPECTED_RESPONSE="process_image_digest_mirror_set: Invalid YAML input"
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 2 ]]
 }
 
 @test "Replace image pullspec: invalid input" {
     run replace_image_pullspec "quay.io/some/image"
-    EXPECTED_RESPONSE="Invalid input. Usage: replace_image_pullspec <image> <mirror>"
+    EXPECTED_RESPONSE="replace_image_pullspec: Usage: replace_image_pullspec <image> <mirror>"
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 2 ]]
 }
 
@@ -356,6 +524,6 @@ EOF
 
 @test "Replace image pullspec: invalid image format" {
     run replace_image_pullspec "registry.io/unavailable/pullspec@sha256:short-sha" "quay.io/some/mirror"
-    EXPECTED_RESPONSE="Invalid pullspec format: registry.io/unavailable/pullspec@sha256:short-sha"
+    EXPECTED_RESPONSE="replace_image_pullspec: invalid pullspec format: registry.io/unavailable/pullspec@sha256:short-sha"
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 2 ]]
 }


### PR DESCRIPTION
Adding more functionality to the utils scripts in order to then reduce
the amount of duplication in task scripts within build-definitions
including:
* Parsing pullspecs
* Getting pullspecs in various forms of digest and tag
* Getting the base image
* Getting a matching FBC catalog image
* Rendering a catalog and reusing the cached output

Combining logic for extracting unique differential properties between a
FBC fragment and its matching catalog image
* Extracting unique bundles from the catalog
* Extracting related images from the catalog

fixes #353

Signed-off-by: arewm <arewm@users.noreply.github.com>