### PR TITLE
fix(KFLUXSPRT-1555): remove bundle images from their related image

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -778,12 +778,15 @@ extract_related_images_from_bundle(){
     exit 2
   fi
 
-  local bundle_render_out related_images
+  local bundle_render_out jq_related_images related_images
   if ! bundle_render_out=$(render_opm -t "${image}"); then
     echo "extract_related_images_from_bundle: failed to render the image ${image}" >&2
     exit 1
   fi
-  related_images=$(echo "${bundle_render_out}" | tr -d '\000-\031' | jq -r '.relatedImages[]?.image')
+  # opm render on a bundle will always add the bundle. We want to make sure that
+  # we strip that out.
+  jq_related_images='[.relatedImages[]?.image] - ["'${image}'"] | .[]'
+  related_images=$(echo "${bundle_render_out}" | tr -d '\000-\031' | jq -r "$jq_related_images")
 
   echo "${related_images}" | tr ' ' '\n'
 }

--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -76,7 +76,7 @@ setup() {
         elif [[ $1 == "render" && $2 == "registry/fbc-fragment:tag@isolated" ]]; then
             echo '{"invalid-control-char": "This is an invalid control char \\t", "schema": "olm.package", "name": "rhbk-operator"}{"schema": "olm.bundle", "package": "rhbk-operator", "image": "registry.redhat.io/rhbk/keycloak-operator-bundle@my-sha", "properties":[], "relatedImages": [{"name": "foo-bar", "image": "registry.redhat.io/foo/bar@sha256:my-bar-sha"}, {"name": "foo-baz", "image": "registry.redhat.io/foo/baz@sha256:my-sha"}]}'
         elif [[ $1 == "render" && $2 == "valid-operator-bundle-1" ]]; then
-            echo '{"schema":"olm.bundle", "relatedImages": [{"name": "", "image": "quay.io/securesign/rhtas-operator:something"}]}'
+            echo '{"schema":"olm.bundle", "relatedImages": [{"name": "", "image": "quay.io/securesign/rhtas-operator:something"},{"name": "", "image": "valid-operator-bundle-1"}]}'
         elif [[ $1 == "render" && $2 == "registry.redhat.io/redhat/redhat-operator-index:v4.15" ]]; then
             echo '{"schema": "olm.package", "name": "rhbk-operator"}{"schema": "olm.bundle", "package": "rhbk-operator", "image": "registry.redhat.io/rhbk/keycloak-operator-bundle@random-image", "properties":[], "relatedImages": [{"name": "foo-baz", "image": "registry.redhat.io/foo/baz@sha256:my-sha"}]}{"schema": "olm.package", "name": "not-rhbk-operator"}{"schema": "olm.bundle", "package": "not-rhbk-operator", "image": "registry.redhat.io/not-rhbk/operator-bundle@not-my-other-sha", "properties":[], "relatedImages": [{"name": "foo-baz", "image": "registry.redhat.io/foo/bar@sha256:my-bar-sha"}]}'
             return 0


### PR DESCRIPTION
`opm render` on a bundle will always add that bundle image to the related images. When processing related images for a bundle, however, we do not want a self-reference.