### PR TITLE
feat(CVP-4399): add function to get bundle's arches

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -973,3 +973,30 @@ get_highest_bundle_version() {
 
   echo "$bundle_image"
 }
+
+# This function will be used by tasks in tekton-integration-catalog
+# Given the output of 'opm render $bundle_image' command, this function returns the supported architectures for the bundle
+get_bundle_arches() {
+  local RENDER_OUT_BUNDLE="$1"
+  local arches
+
+  # Validate input parameters
+  if [[ -z "$RENDER_OUT_BUNDLE" ]]; then
+    echo "get_bundle_arches: Invalid input. Usage: get_bundle_arches <RENDER_OUT_BUNDLE>" >&2
+    exit 2
+  fi
+
+  arches=$(echo "$RENDER_OUT_BUNDLE" | tr -d '\000-\031' | jq -r '
+    select(.schema == "olm.bundle") 
+    | .properties[]? 
+    | select(.type == "olm.csv.metadata").value.labels 
+    | if . then keys[] | select(startswith("operatorframework.io/arch.")) | sub("operatorframework.io/arch.";"") else empty end
+  ')
+
+  if [[ -z "$arches" ]]; then
+    echo "get_bundle_arches: Error: No architectures found for bundle image." >&2
+    exit 1
+  fi
+
+  echo "$arches"
+}

--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -730,3 +730,53 @@ EOF
     echo "${output}"
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }
+
+@test "Get bundle arches: success" {
+    RENDER_OUT_BUNDLE=$(cat <<EOF
+{
+    "schema": "olm.bundle",
+    "name": "kubevirt-hyperconverged-operator.v4.16.7",
+    "package": "kubevirt-hyperconverged",
+    "image": "registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:5a75810bdebb97c63cad1d25fe0399ed189b558b50ee6dc1cb61f75f9116aa89",
+    "properties": [
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported",
+                    "operatorframework.io/os.linux": "supported"
+                }
+            }
+        }
+    ]
+}
+EOF
+)
+    run get_bundle_arches "${RENDER_OUT_BUNDLE}"
+    EXPECTED_RESPONSE=$(echo "amd64 arm64 ppc64le s390x"  | tr ' ' '\n')
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get bundle arches: no arches found" {
+    RENDER_OUT_BUNDLE=$(cat <<EOF
+{
+    "schema": "olm.bundle",
+    "name": "kubevirt-hyperconverged-operator.v4.16.7",
+    "package": "kubevirt-hyperconverged",
+    "image": "registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:5a75810bdebb97c63cad1d25fe0399ed189b558b50ee6dc1cb61f75f9116aa89",
+    "properties": [
+        {
+            "type": "olm.csv.metadata",
+            "value": {}
+        }
+    ]
+}
+EOF
+)
+    run get_bundle_arches "${RENDER_OUT_BUNDLE}"
+    EXPECTED_RESPONSE="get_bundle_arches: Error: No architectures found for bundle image."
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
+}


### PR DESCRIPTION
This commit adds a get_bundle_arches function which takes rendered FBC, bundle image and FBC fragment's target OCP version, and returns bundle supported architectures.