### PR TITLE
chore(stoneintg-1134): update github workflows to ubuntu-24.04

### DIFF
--- a/.github/workflows/clam-db.yaml
+++ b/.github/workflows/clam-db.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   build:
     name: Build the new image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/clam-ver-check.yaml
+++ b/.github/workflows/clam-ver-check.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: Check for latest clamav version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
      - name: Get clamav version from latest konflux-test release

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -111,7 +111,7 @@ jobs:
   gitlint:
     name: Run gitlint checks
     if: ${{ github.event_name == 'pull_request' }}  # we can test only PRs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
 
   github-release:
     name: Build and push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - call-build-test-and-push-workflow
     steps:


### PR DESCRIPTION
The ubuntu-20.04 image for github actions is being deprecated. Workflows that still rely on the image after April 1, 2025 willl no longer work. We need to update to ubuntu-24.04 to avoid this.