### PR TITLE
chore: remove Pat from dependabot.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,6 @@ updates:
       - "sonam1412"
       - "dheerajodha"
       - "14rcole"
-      - "chipspeak"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -38,7 +37,6 @@ updates:
       - "sonam1412"
       - "dheerajodha"
       - "14rcole"
-      - "chipspeak"
   - package-ecosystem: "docker"
     directory: "/clamav"
     schedule:
@@ -54,4 +52,3 @@ updates:
       - "sonam1412"
       - "dheerajodha"
       - "14rcole"
-      - "chipspeak"


### PR DESCRIPTION
* this is because Pat has left integration-service team and I would like to make his life a litte bit better.