### PR TITLE
chore: ignore author red-hat-konflux in .gitlint

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -14,4 +14,4 @@ line-length=72
 [contrib-title-conventional-commits]
 
 [ignore-by-author-name]
-regex=(.*)dependabot(.*)
+regex=(.*)(dependabot|red-hat-konflux)(.*)


### PR DESCRIPTION
* ignore author red-hat-konflux in .gitlint since the pr from it has long title and Signed-off-by, such as https://github.com/konflux-ci/konflux-test/pull/408

Signed-off-by: Hongwei Liu <hongliu@redhat.com>


