### PR TITLE
fix: return null when suggested-namespace annotation is not defined

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -1105,14 +1105,8 @@ get_bundle_suggested_namespace() {
   local namespace
   namespace=$(echo "$RENDER_OUT_BUNDLE" | tr -d '\000-\031' | jq -r '
     .properties[]? 
-    | select(.type == "olm.csv.metadata") 
+    | select(.type == "olm.csv.metadata" and (.value | type == "object"))
     | .value.annotations["operatorframework.io/suggested-namespace"]')
-
-  # Ensure namespace is not empty
-  if [[ -z "$namespace" || "$namespace" == "null" ]]; then
-    echo "get_bundle_suggested_namespace: No suggested namespace found in bundle" >&2
-    exit 1
-  fi
 
   echo "$namespace"
 }

--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -1028,7 +1028,7 @@ EOF
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
-@test "Get bundle suggested namespace: failure" {
+@test "Get bundle suggested namespace: suggested namespace is not defined" {
     RENDER_OUT_BUNDLE=$(cat <<EOF
 {
     "schema": "olm.bundle",
@@ -1045,8 +1045,8 @@ EOF
 EOF
 )
     run get_bundle_suggested_namespace "${RENDER_OUT_BUNDLE}"
-    EXPECTED_RESPONSE="get_bundle_suggested_namespace: No suggested namespace found in bundle"
-    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
+    EXPECTED_RESPONSE=null
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
 @test "Get bundle suggested namespace: no olm.csv.metadata found" {


### PR DESCRIPTION
Return null instead of exiting with code 1 when suggested-namespace annotation is missing. Since the deployment test  will create a namespace if needed, failing early is unnecessary.