### PR TITLE
feat: added findutils to clam-db image for parallel processing

### DIFF
--- a/clamav/Dockerfile
+++ b/clamav/Dockerfile
@@ -11,6 +11,7 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.
     jq \
     tar \
     skopeo \
+    findutils \
     && microdnf clean all
 
 COPY ./test/utils.sh /utils.sh


### PR DESCRIPTION
Adding `findutils` to the microdnf install list of packages.  This is to make `find` available to the updates to the clamav-scan task that adds parallel processing for performance improvement.  See PR: https://github.com/konflux-ci/build-definitions/pull/2262