### PR TITLE
feat(CLOUDDST-27082): resolve arch specific digest

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -1199,3 +1199,29 @@ retry() {
       sleep "${interval}"
   done
 }
+
+# This function will be used by tasks in tekton-integration-catalog
+# Update the image digest with the 0th manifest
+resolve_to_0th_manifest_digest() {
+  local image_url="$1"
+
+  # Validate input parameters
+  if [[ -z "$image_url" ]]; then
+    echo "resolve_to_0th_manifest_digest: Invalid input. Usage: resolve_to_0th_manifest_digest <image_url>" >&2
+    exit 2
+  fi
+
+  # Get image manifests as a map of {arch:digest}
+  local manifests
+  manifests=$(get_image_manifests -i "$image_url")
+
+  # Extract 0th manifest's digest
+  local new_digest
+  new_digest=$(echo "$manifests" | jq -r 'to_entries[0].value')
+
+  # Remove an existing digest from the original image
+  local image_no_digest
+  image_no_digest=$(get_image_registry_repository_tag "$image_url")
+
+  echo -n "${image_no_digest}@${new_digest}"
+}

--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -1195,3 +1195,9 @@ EOF
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 
 }
+
+@test "Resolve to 0th manifest digest: success" {
+    run resolve_to_0th_manifest_digest registry/image@valid-url
+    EXPECTED_RESPONSE="registry/image@valid-manifest-amd64"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}


### PR DESCRIPTION
This commit adds a new function that takes a FBC fragment image, and checks the number of manifests.
If the image is an index (multi-arch), replace the digest with the 0th manifest's digest;
If it's a single-arch image manifest, leave it unchanged.

Related slack thread: https://redhat-internal.slack.com/archives/C074JM28DTP/p1746026536055699