### PR TITLE
Ignore the cosign updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     commit-message:
       # Prefix all commit messages with "chore(Dockerfile): "
       prefix: "chore(Dockerfile): "
+    ignore:
+      # Ignore updates to cosign packages
+      - dependency-name: "sigstore/cosign/cosign"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
In the past we have received a bogus version of cosign through dependabot which has caused issues on the deprecated-image-check.
This change is to disable the udpdates for cosign from dependabot.
