### PR TITLE
chore: disable github actions build

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -39,13 +39,6 @@ jobs:
           dockerfile: Dockerfile
           ignore: DL3003,DL3013,DL3041,DL4006  # DL4006 seems broken
 
-  call-build-and-test-workflow:
-    name: Call build and test workflow
-    uses: ./.github/workflows/build_reusable.yaml
-    with:
-      tags: ${{ github.sha }}
-    secrets: inherit
-
   opa_policies_unittest:
     name: opa_policies_unittest
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github Actions build no longer works now that we are using the registry.redhat.io cosign image.  It is also no longer needed as we are building in Konflux.  This PR disables the build that automatically occurs when new PRs are created or existing PRs are updated.