### PR TITLE
fix(KONFLUX-9831): fix get_bundle_arches to default to amd64

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -983,7 +983,9 @@ get_highest_bundle_version() {
 }
 
 # This function will be used by tasks in tekton-integration-catalog
-# Given the output of 'opm render $bundle_image' command, this function returns the supported architectures for the bundle
+# Given the output of 'opm render $bundle_image' command, this function returns the supported architectures for the bundle.
+# If the architecture labels are not defined in the bundle CSV, the function defaults to returning "amd64".
+# Source: https://spaces.redhat.com/spaces/CFC/pages/124105424/Delivery#Delivery-BundleImages(OperatorMetadata)
 get_bundle_arches() {
   local RENDER_OUT_BUNDLE="$1"
   local arches
@@ -1003,9 +1005,9 @@ get_bundle_arches() {
     | scan("^operatorframework.io/arch.\\K.*")
   ')
 
+  # Default to amd64 if no architectures are found
   if [[ -z "$arches" ]]; then
-    echo "get_bundle_arches: Error: No architectures found for bundle image." >&2
-    exit 1
+    arches="amd64"
   fi
 
   echo "$arches"

--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -899,8 +899,8 @@ EOF
 EOF
 )
     run get_bundle_arches "${RENDER_OUT_BUNDLE}"
-    EXPECTED_RESPONSE="get_bundle_arches: Error: No architectures found for bundle image."
-    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
+    EXPECTED_RESPONSE="amd64"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
 }
 
 @test "Group bundle images by package: two packages" {


### PR DESCRIPTION
This commit fixes get_bundle_arches function to default to amd64 in case the arch labels are not defined in the bundle CSV.
Source: https://spaces.redhat.com/spaces/CFC/pages/124105424/Delivery#Delivery-BundleImages(OperatorMetadata)