### PR TITLE
fix clamav rego parse error

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependency packages
         run: |
          sudo apt-get install jq
-         sudo curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/v0.56.0/opa_linux_amd64_static
+         sudo curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
          sudo chmod 755 /usr/bin/opa
 
       - name: Run unittests for policies

--- a/policies/clair/vulnerabilities-check.rego
+++ b/policies/clair/vulnerabilities-check.rego
@@ -1,146 +1,145 @@
 package required_checks
 
 # function to get mapping {rpm: set of vulnerabilities names}; duplicated vulnerabilities are removed
-get_patched_vulnerabilities(input_data, severity) := vulnerabilities {
-  vulnerabilities := [{"name": rpm.Name, "version": rpm.Version, "vulnerabilities": vuln} |
-    rpm := input_data.data[_].Features[_]
-    vuln := {v.Name | v:=rpm.Vulnerabilities[_]; v.Severity == severity; v.FixedBy != ""; contains(v.Link,"RHSA")}
-    count(vuln) > 0
-  ]
+get_patched_vulnerabilities(input_data, severity) := vulnerabilities if {
+	vulnerabilities := [{"name": rpm.Name, "version": rpm.Version, "vulnerabilities": vuln} |
+		rpm := input_data.data[_].Features[_]
+		vuln := {v.Name | v := rpm.Vulnerabilities[_]; v.Severity == severity; v.FixedBy != ""; contains(v.Link, "RHSA")}
+		count(vuln) > 0
+	]
 }
 
 # function to get mapping {rpm: set of vulnerabilities names}; duplicated vulnerabilities are removed
-get_unpatched_vulnerabilities(input_data, severity) := vulnerabilities {
-  vulnerabilities := [{"name": rpm.Name, "version": rpm.Version, "vulnerabilities": vuln} |
-    rpm := input_data.data[_].Features[_]
-    vuln := {v.Name | v:=rpm.Vulnerabilities[_]; v.Severity == severity; any([v.FixedBy == "", contains(v.Link,"RHSA") == false ])}
-    count(vuln) > 0
-  ]
+get_unpatched_vulnerabilities(input_data, severity) := vulnerabilities if {
+	vulnerabilities := [{"name": rpm.Name, "version": rpm.Version, "vulnerabilities": vuln} |
+		rpm := input_data.data[_].Features[_]
+		vuln := {v.Name | v := rpm.Vulnerabilities[_]; v.Severity == severity; [v.FixedBy == "", contains(v.Link, "RHSA") == false]}
+		count(vuln) > 0
+	]
 }
 
-
 # function returns count of all vulnerabilities
-count_vulnerabilities(vulnerabilities) := cnt {
-  cnt := sum([count(v.vulnerabilities) | v:=vulnerabilities[_]])
+count_vulnerabilities(vulnerabilities) := cnt if {
+	cnt := sum([count(v.vulnerabilities) | v := vulnerabilities[_]])
 }
 
 # function generates description with RPMs and their vulnerabilities
-generate_description(vulnerabilities) := dsc {
-  dsc := sprintf("Vulnerabilities found: %s", [concat(", ",
-                   [sprintf("%s-%s (%s)", [v.name, v.version, concat(", ", v.vulnerabilities)]) | v := vulnerabilities[_]]
-                 )])
+generate_description(vulnerabilities) := dsc if {
+	dsc := sprintf("Vulnerabilities found: %s", [concat(", ",
+		[sprintf("%s-%s (%s)", [v.name, v.version, concat(", ", v.vulnerabilities)]) | v := vulnerabilities[_]]
+	)])
 }
 
-warn_critical_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_critical_vulnerabilities := get_patched_vulnerabilities(input, "Critical")
-  not count(rpms_with_critical_vulnerabilities) == 0
+warn_critical_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+	rpms_with_critical_vulnerabilities := get_patched_vulnerabilities(input, "Critical")
+	not count(rpms_with_critical_vulnerabilities) == 0
 
-  name := "clair_critical_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_critical_vulnerabilities)
-  msg := "Found packages with critical vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description := generate_description(rpms_with_critical_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_critical_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_critical_vulnerabilities)
+	msg := "Found packages with critical vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	description := generate_description(rpms_with_critical_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-warn_unpatched_critical_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_unpatched_critical_vulnerabilities := get_unpatched_vulnerabilities(input, "Critical")
-  not count(rpms_with_unpatched_critical_vulnerabilities) == 0
+warn_unpatched_critical_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+	rpms_with_unpatched_critical_vulnerabilities := get_unpatched_vulnerabilities(input, "Critical")
+	not count(rpms_with_unpatched_critical_vulnerabilities) == 0
 
-  name := "clair_unpatched_critical_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_unpatched_critical_vulnerabilities)
-  msg := "Found packages with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := generate_description(rpms_with_unpatched_critical_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unpatched_critical_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_unpatched_critical_vulnerabilities)
+	msg := "Found packages with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := generate_description(rpms_with_unpatched_critical_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-warn_high_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_high_vulnerabilities := get_patched_vulnerabilities(input, "High")
-  not count(rpms_with_high_vulnerabilities) == 0
+warn_high_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+	rpms_with_high_vulnerabilities := get_patched_vulnerabilities(input, "High")
+	not count(rpms_with_high_vulnerabilities) == 0
 
-  name := "clair_high_vulnerabilities"
-  vulns_num = count_vulnerabilities(rpms_with_high_vulnerabilities)
-  msg := "Found packages with high vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description := generate_description(rpms_with_high_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_high_vulnerabilities"
+	vulns_num = count_vulnerabilities(rpms_with_high_vulnerabilities)
+	msg := "Found packages with high vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	description := generate_description(rpms_with_high_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-warn_unpatched_high_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_unpatched_high_vulnerabilities := get_unpatched_vulnerabilities(input, "High")
-  not count(rpms_with_unpatched_high_vulnerabilities) == 0
+warn_unpatched_high_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+	rpms_with_unpatched_high_vulnerabilities := get_unpatched_vulnerabilities(input, "High")
+	not count(rpms_with_unpatched_high_vulnerabilities) == 0
 
-  name := "clair_unpatched_high_vulnerabilities"
-  vulns_num = count_vulnerabilities(rpms_with_unpatched_high_vulnerabilities)
-  msg := "Found packages with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := generate_description(rpms_with_unpatched_high_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unpatched_high_vulnerabilities"
+	vulns_num = count_vulnerabilities(rpms_with_unpatched_high_vulnerabilities)
+	msg := "Found packages with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := generate_description(rpms_with_unpatched_high_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-warn_medium_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_medium_vulnerabilities := get_patched_vulnerabilities(input, "Medium")
-  not count(rpms_with_medium_vulnerabilities) == 0
+warn_medium_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+	rpms_with_medium_vulnerabilities := get_patched_vulnerabilities(input, "Medium")
+	not count(rpms_with_medium_vulnerabilities) == 0
 
-  name := "clair_medium_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_medium_vulnerabilities)
-  msg := "Found packages with medium vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description := generate_description(rpms_with_medium_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_medium_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_medium_vulnerabilities)
+	msg := "Found packages with medium vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	description := generate_description(rpms_with_medium_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-warn_unpatched_medium_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_unpatched_medium_vulnerabilities := get_unpatched_vulnerabilities(input, "Medium")
-  not count(rpms_with_unpatched_medium_vulnerabilities) == 0
+warn_unpatched_medium_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+	rpms_with_unpatched_medium_vulnerabilities := get_unpatched_vulnerabilities(input, "Medium")
+	not count(rpms_with_unpatched_medium_vulnerabilities) == 0
 
-  name := "clair_unpatched_medium_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_unpatched_medium_vulnerabilities)
-  msg := "Found packages with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := generate_description(rpms_with_unpatched_medium_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unpatched_medium_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_unpatched_medium_vulnerabilities)
+	msg := "Found packages with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := generate_description(rpms_with_unpatched_medium_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-warn_low_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_low_vulnerabilities := get_patched_vulnerabilities(input, "Low")
-  rpms_with_negligible_vulnerabilities := get_patched_vulnerabilities(input, "Negligible")
-  rpms_with_low_neg_vulnerabilities = array.concat(rpms_with_low_vulnerabilities, rpms_with_negligible_vulnerabilities)
-  not count(rpms_with_low_neg_vulnerabilities) == 0
+warn_low_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+	rpms_with_low_vulnerabilities := get_patched_vulnerabilities(input, "Low")
+	rpms_with_negligible_vulnerabilities := get_patched_vulnerabilities(input, "Negligible")
+	rpms_with_low_neg_vulnerabilities = array.concat(rpms_with_low_vulnerabilities, rpms_with_negligible_vulnerabilities)
+	not count(rpms_with_low_neg_vulnerabilities) == 0
 
-  name := "clair_low_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_low_neg_vulnerabilities)
-  msg := "Found packages with low/negligible vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description := generate_description(rpms_with_low_neg_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_low_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_low_neg_vulnerabilities)
+	msg := "Found packages with low/negligible vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	description := generate_description(rpms_with_low_neg_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-warn_unpatched_low_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_unpatched_low_vulnerabilities := get_unpatched_vulnerabilities(input, "Low")
-  rpms_with_unpatched_negligible_vulnerabilities := get_unpatched_vulnerabilities(input, "Negligible")
-  rpms_with_unpatched_low_neg_vulnerabilities = array.concat(rpms_with_unpatched_low_vulnerabilities, rpms_with_unpatched_negligible_vulnerabilities)
-  not count(rpms_with_unpatched_low_neg_vulnerabilities) == 0
+warn_unpatched_low_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+	rpms_with_unpatched_low_vulnerabilities := get_unpatched_vulnerabilities(input, "Low")
+	rpms_with_unpatched_negligible_vulnerabilities := get_unpatched_vulnerabilities(input, "Negligible")
+	rpms_with_unpatched_low_neg_vulnerabilities = array.concat(rpms_with_unpatched_low_vulnerabilities, rpms_with_unpatched_negligible_vulnerabilities)
+	not count(rpms_with_unpatched_low_neg_vulnerabilities) == 0
 
-  name := "clair_unpatched_low_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_unpatched_low_neg_vulnerabilities)
-  msg := "Found packages with unpatched low/negligible vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := generate_description(rpms_with_unpatched_low_neg_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unpatched_low_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_unpatched_low_neg_vulnerabilities)
+	msg := "Found packages with unpatched low/negligible vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := generate_description(rpms_with_unpatched_low_neg_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-warn_unknown_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_unknown_vulnerabilities := get_patched_vulnerabilities(input, "Unknown")
-  not count(rpms_with_unknown_vulnerabilities) == 0
+warn_unknown_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+	rpms_with_unknown_vulnerabilities := get_patched_vulnerabilities(input, "Unknown")
+	not count(rpms_with_unknown_vulnerabilities) == 0
 
-  name := "clair_unknown_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_unknown_vulnerabilities)
-  msg := "Found packages with unknown vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description := generate_description(rpms_with_unknown_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unknown_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_unknown_vulnerabilities)
+	msg := "Found packages with unknown vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	description := generate_description(rpms_with_unknown_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-warn_unpatched_unknown_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_unpatched_unknown_vulnerabilities := get_unpatched_vulnerabilities(input, "Unknown")
-  not count(rpms_with_unpatched_unknown_vulnerabilities) == 0
+warn_unpatched_unknown_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+	rpms_with_unpatched_unknown_vulnerabilities := get_unpatched_vulnerabilities(input, "Unknown")
+	not count(rpms_with_unpatched_unknown_vulnerabilities) == 0
 
-  name := "clair_unpatched_unknown_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_unpatched_unknown_vulnerabilities)
-  msg := "Found packages with unpatched unknown vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := generate_description(rpms_with_unpatched_unknown_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unpatched_unknown_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_unpatched_unknown_vulnerabilities)
+	msg := "Found packages with unpatched unknown vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := generate_description(rpms_with_unpatched_unknown_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }

--- a/policies/clamav/virus-check.rego
+++ b/policies/clamav/virus-check.rego
@@ -2,7 +2,7 @@ package required_checks
 
 import future.keywords.in
 
-violation_infected_files[{"msg": msg, "details": {"filename": filename, "virname": virname, "description": description}}] {
+violation_infected_files contains {"msg": msg, "details": {"filename": filename, "virname": virname, "description": description}} if {
 	hit := _report.hits[_]
 
 	filename := hit.filename
@@ -13,7 +13,7 @@ violation_infected_files[{"msg": msg, "details": {"filename": filename, "virname
 	not hit.is_heuristic # we don't want heursitics checks to cause false positive failures
 }
 
-warn_heuristic_malware_files[{"msg": msg, "details": {"filename": filename, "virname": virname, "description": description}}] {
+warn_heuristic_malware_files contains {"msg": msg, "details": {"filename": filename, "virname": virname, "description": description}} if {
 	hit := _report.hits[_]
 
 	filename := hit.filename
@@ -24,7 +24,7 @@ warn_heuristic_malware_files[{"msg": msg, "details": {"filename": filename, "vir
 	hit.is_heuristic # we want to only warn for heuristic checks
 }
 
-_report := d {
+_report := d if {
 	marker := "----------- SCAN SUMMARY -----------"
 	marker_parts := split(input.output, marker)
 	hits_lines := split(marker_parts[0], "\n")

--- a/policies/image/deprecated-labels.rego
+++ b/policies/image/deprecated-labels.rego
@@ -1,73 +1,75 @@
 package required_checks
 
-violation_install_deprecated[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["INSTALL"]
+import rego.v1
 
-  name := "install_label_deprecated"
-  msg := "The INSTALL label is deprecated!"
-  description := "The 'INSTALL' label is deprecated, replace with 'install'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+violation_install_deprecated contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels.INSTALL
+
+	name := "install_label_deprecated"
+	msg := "The INSTALL label is deprecated!"
+	description := "The 'INSTALL' label is deprecated, replace with 'install'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_architecture_deprecated[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["Architecture"]
+violation_architecture_deprecated contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels.Architecture
 
-  name := "architecture_label_deprecated"
-  msg := "The Architecture label is deprecated!"
-  description := "The 'Architecture' label is deprecated, replace with 'architecture'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "architecture_label_deprecated"
+	msg := "The Architecture label is deprecated!"
+	description := "The 'Architecture' label is deprecated, replace with 'architecture'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_name_deprecated[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["Name"]
+violation_name_deprecated contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels.Name
 
-  name := "name_label_deprecated"
-  msg := "The Name label is deprecated!"
-  description := "The 'Name' label is deprecated, replace with 'name'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "name_label_deprecated"
+	msg := "The Name label is deprecated!"
+	description := "The 'Name' label is deprecated, replace with 'name'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_release_deprecated[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["Release"]
+violation_release_deprecated contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels.Release
 
-  name := "release_label_deprecated"
-  msg := "The Release label is deprecated!"
-  description := "The 'Release' label is deprecated, replace with 'release'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "release_label_deprecated"
+	msg := "The Release label is deprecated!"
+	description := "The 'Release' label is deprecated, replace with 'release'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_uninstall_deprecated[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["UNINSTALL"]
+violation_uninstall_deprecated contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels.UNINSTALL
 
-  name := "uninstall_label_deprecated"
-  msg := "The UNINSTALL label is deprecated!"
-  description := "The 'UNINSTALL' label is deprecated, replace with 'uninstall'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "uninstall_label_deprecated"
+	msg := "The UNINSTALL label is deprecated!"
+	description := "The 'UNINSTALL' label is deprecated, replace with 'uninstall'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_version_deprecated[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["Version"]
+violation_version_deprecated contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels.Version
 
-  name := "version_label_deprecated"
-  msg := "The Version label is deprecated!"
-  description := "The 'Version' label is deprecated, replace with 'version'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "version_label_deprecated"
+	msg := "The Version label is deprecated!"
+	description := "The 'Version' label is deprecated, replace with 'version'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_bzcomponent_deprecated[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["BZComponent"]
+violation_bzcomponent_deprecated contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels.BZComponent
 
-  name := "bzcomponent_label_deprecated"
-  msg := "The BZComponent label is deprecated!"
-  description := "The BZComponent label is deprecated, replace with 'com.redhat.component'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "bzcomponent_label_deprecated"
+	msg := "The BZComponent label is deprecated!"
+	description := "The BZComponent label is deprecated, replace with 'com.redhat.component'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_run_deprecated[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["RUN"]
+violation_run_deprecated contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels.RUN
 
-  name := "run_label_deprecated"
-  msg := "The RUN label is deprecated!"
-  description := "The 'RUN' label is deprecated, replace with 'run'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "run_label_deprecated"
+	msg := "The RUN label is deprecated!"
+	description := "The 'RUN' label is deprecated, replace with 'run'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }

--- a/policies/image/fbc-labels.rego
+++ b/policies/image/fbc-labels.rego
@@ -1,10 +1,12 @@
 package fbc_checks
 
-violation_fbc_dc_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["operators.operatorframework.io.index.configs.v1"]
+import rego.v1
 
-  name := "operators_operatorframework_io_index_configs_v1_label_required"
-  msg := "The 'operators.operatorframework.io.index.configs.v1' label should be defined for FBC image"
-  description := "Should set DC-specific label `operators.operatorframework.io.index.configs.v1` for the location of the DC root directory for FBC image."
-  url := "https://docs.openshift.com/container-platform/4.9/operators/admin/olm-managing-custom-catalogs.html#olm-creating-fb-catalog-image_olm-managing-custom-catalogs"
+violation_fbc_dc_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels["operators.operatorframework.io.index.configs.v1"]
+
+	name := "operators_operatorframework_io_index_configs_v1_label_required"
+	msg := "The 'operators.operatorframework.io.index.configs.v1' label should be defined for FBC image"
+	description := "Should set DC-specific label `operators.operatorframework.io.index.configs.v1` for the location of the DC root directory for FBC image."
+	url := "https://docs.openshift.com/container-platform/4.9/operators/admin/olm-managing-custom-catalogs.html#olm-creating-fb-catalog-image_olm-managing-custom-catalogs"
 }

--- a/policies/image/inherited-labels.rego
+++ b/policies/image/inherited-labels.rego
@@ -1,48 +1,50 @@
 package optional_checks
 
+import rego.v1
+
 import data as base_image
 
-violation_summary_label_inherited[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["summary"] == base_image.Labels["summary"]
+violation_summary_label_inherited contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels.summary == base_image.Labels.summary
 
-  name := "summary_label_inherited"
-  msg := "The 'summary' label should not be inherited from the base image"
-  description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
+	name := "summary_label_inherited"
+	msg := "The 'summary' label should not be inherited from the base image"
+	description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
 }
 
-violation_description_label_inherited[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["description"] == base_image.Labels["description"]
+violation_description_label_inherited contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels.description == base_image.Labels.description
 
-  name := "description_label_inherited"
-  msg := "The 'description' label should not be inherited from the base image"
-  description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
+	name := "description_label_inherited"
+	msg := "The 'description' label should not be inherited from the base image"
+	description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
 }
 
-violation_io_k8s_description_label_inherited[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["io.k8s.description"] == base_image.Labels["io.k8s.description"]
+violation_io_k8s_description_label_inherited contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels["io.k8s.description"] == base_image.Labels["io.k8s.description"]
 
-  name := "io_k8s_description_label_inherited"
-  msg := "The 'io.k8s.description' label should not be inherited from the base image"
-  description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
+	name := "io_k8s_description_label_inherited"
+	msg := "The 'io.k8s.description' label should not be inherited from the base image"
+	description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
 }
 
-violation_io_k8s_display_name_label_inherited[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["io.k8s.display-name"] == base_image.Labels["io.k8s.display-name"]
+violation_io_k8s_display_name_label_inherited contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels["io.k8s.display-name"] == base_image.Labels["io.k8s.display-name"]
 
-  name := "io_k8s_display_name_label_inherited"
-  msg := "The 'io.k8s.display-name' label should not be inherited from the base image"
-  description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
+	name := "io_k8s_display_name_label_inherited"
+	msg := "The 'io.k8s.display-name' label should not be inherited from the base image"
+	description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
 }
 
-violation_io_openshift_tags_label_inherited[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.Labels["io.openshift.tags"] == base_image.Labels["io.openshift.tags"]
+violation_io_openshift_tags_label_inherited contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.Labels["io.openshift.tags"] == base_image.Labels["io.openshift.tags"]
 
-  name := "io_openshift_tags_label_inherited"
-  msg := "The 'io.openshift.tags' label should not be inherited from the base image"
-  description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
+	name := "io_openshift_tags_label_inherited"
+	msg := "The 'io.openshift.tags' label should not be inherited from the base image"
+	description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
 }

--- a/policies/image/optional-labels.rego
+++ b/policies/image/optional-labels.rego
@@ -1,19 +1,19 @@
 package optional_checks
 
-violation_maintainer_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["maintainer"]
+violation_maintainer_required[{"details": {"description": description, "name": name, "url": url}, "msg": msg}] if {
+	not input.Labels.maintainer
 
-  name := "maintainer_label_required"
-  msg := "The 'maintainer' label should be defined"
-  description := "The name and email of the maintainer (usually the submitter). Should contain `@redhat.com` or `Red Hat`."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "maintainer_label_required"
+	msg := "The 'maintainer' label should be defined"
+	description := "The name and email of the maintainer (usually the submitter). Should contain `@redhat.com` or `Red Hat`."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_summary_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["summary"]
+violation_summary_required[{"details": {"description": description, "name": name, "url": url}, "msg": msg}] if {
+	not input.Labels.summary
 
-  name := "summary_label_required"
-  msg := "The 'summary' label should be defined"
-  description := "A short description of the image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "summary_label_required"
+	msg := "The 'summary' label should be defined"
+	description := "A short description of the image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }

--- a/policies/image/required-labels.rego
+++ b/policies/image/required-labels.rego
@@ -1,118 +1,120 @@
 package required_checks
 
-violation_name_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["name"]
+import rego.v1
 
-  name := "name_label_required"
-  msg := "The required 'name' label is missing!"
-  description := "Name of the Image or Container."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+violation_name_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels.name
+
+	name := "name_label_required"
+	msg := "The required 'name' label is missing!"
+	description := "Name of the Image or Container."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_com_redhat_component_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["com.redhat.component"]
+violation_com_redhat_component_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels["com.redhat.component"]
 
-  name := "com_redhat_component_label_required!"
-  msg := "The required 'com.redhat.component' label is missing"
-  description := "The Bugzilla component name where bugs against this container should be reported by users."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "com_redhat_component_label_required!"
+	msg := "The required 'com.redhat.component' label is missing"
+	description := "The Bugzilla component name where bugs against this container should be reported by users."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_version_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["version"]
+violation_version_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels.version
 
-  name := "version_label_required"
-  msg := "The required 'version' label is missing!"
-  description := "Version of the image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "version_label_required"
+	msg := "The required 'version' label is missing!"
+	description := "Version of the image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_description_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["description"]
+violation_description_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels.description
 
-  name := "description_label_required"
-  msg := "The required 'description' label is missing!"
-  description := "Detailed description of the image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "description_label_required"
+	msg := "The required 'description' label is missing!"
+	description := "Detailed description of the image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_io_k8s_description_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["io.k8s.description"]
+violation_io_k8s_description_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels["io.k8s.description"]
 
-  name := "io_k8s_description_label_required"
-  msg := "The required 'io.k8s.description' label is missing!"
-  description := "Description of the container displayed in Kubernetes."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "io_k8s_description_label_required"
+	msg := "The required 'io.k8s.description' label is missing!"
+	description := "Description of the container displayed in Kubernetes."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_vcs_ref_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["vcs-ref"]
+violation_vcs_ref_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels["vcs-ref"]
 
-  name := "vcs_ref_label_required"
-  msg := "The required 'vcs-ref' label is missing!"
-  description := "A 'reference' within the version control repository; e.g. a git commit, or a subversion branch."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "vcs_ref_label_required"
+	msg := "The required 'vcs-ref' label is missing!"
+	description := "A 'reference' within the version control repository; e.g. a git commit, or a subversion branch."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_vcs_type_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["vcs-type"]
+violation_vcs_type_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels["vcs-type"]
 
-  name := "vcs_type_label_required"
-  msg := "The required 'vcs-type' label is missing!"
-  description := "The type of version control used by the container source. Generally one of git, hg, svn, bzr, cvs"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "vcs_type_label_required"
+	msg := "The required 'vcs-type' label is missing!"
+	description := "The type of version control used by the container source. Generally one of git, hg, svn, bzr, cvs"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_architecture_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["architecture"]
+violation_architecture_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels.architecture
 
-  name := "architecture_label_required"
-  msg := "The required 'architecture' label is missing!"
-  description := "Architecture the software in the image should target."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "architecture_label_required"
+	msg := "The required 'architecture' label is missing!"
+	description := "Architecture the software in the image should target."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_vendor_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["vendor"]
+violation_vendor_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels.vendor
 
-  name := "vendor_label_required"
-  msg := "The required 'vendor' label is missing!"
-  description := "Name of the vendor."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "vendor_label_required"
+	msg := "The required 'vendor' label is missing!"
+	description := "Name of the vendor."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_release_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["release"]
+violation_release_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels.release
 
-  name := "release_label_required"
-  msg := "The required 'release' label is missing!"
-  description := "Release Number for this version."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "release_label_required"
+	msg := "The required 'release' label is missing!"
+	description := "Release Number for this version."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_url_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["url"]
+violation_url_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels.url
 
-  name := "url_label_required"
-  msg := "The required 'url' label is missing!"
-  description := "A URL where the user can find more information about the image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "url_label_required"
+	msg := "The required 'url' label is missing!"
+	description := "A URL where the user can find more information about the image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_build_date_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["build-date"]
+violation_build_date_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels["build-date"]
 
-  name := "build_date_label_required"
-  msg := "The required 'build-date' label is missing!"
-  description := "Date/Time image was built as RFC 3339 date-time."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "build_date_label_required"
+	msg := "The required 'build-date' label is missing!"
+	description := "Date/Time image was built as RFC 3339 date-time."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_distribution_scope_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["distribution-scope"]
+violation_distribution_scope_required contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	not input.Labels["distribution-scope"]
 
-  name := "distribution_scope_label_required"
-  msg := "The required 'distribution-scope' label is missing!"
-  description := "Scope of intended distribution of the image. (private/authoritative-source-only/restricted/public)."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "distribution_scope_label_required"
+	msg := "The required 'distribution-scope' label is missing!"
+	description := "Scope of intended distribution of the image. (private/authoritative-source-only/restricted/public)."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }

--- a/policies/repository/deprecated-image.rego
+++ b/policies/repository/deprecated-image.rego
@@ -1,10 +1,12 @@
 package required_checks
 
-violation_image_repository_deprecated[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  input.release_categories[_] == "Deprecated"
+import rego.v1
 
-  name := "image_repository_deprecated"
-  msg := "The container image shouldn't be built from a repository that is marked as 'Deprecated' in Red Hat Catalog."
-  description := "Deprecated images are no longer maintained and will accumulate security vulnerabilities without releasing a fixed version."
-  url := "https://redhat-connect.gitbook.io/catalog-help/container-images/container-image-details/container-image-release-categories"
+violation_image_repository_deprecated contains {"msg": msg, "details": {"name": name, "description": description, "url": url}} if {
+	input.release_categories[_] == "Deprecated"
+
+	name := "image_repository_deprecated"
+	msg := "The container image shouldn't be built from a repository that is marked as 'Deprecated' in Red Hat Catalog."
+	description := "Deprecated images are no longer maintained and will accumulate security vulnerabilities without releasing a fixed version."
+	url := "https://redhat-connect.gitbook.io/catalog-help/container-images/container-image-details/container-image-release-categories"
 }

--- a/policies/rpm_manifest/unsigned-rpms.rego
+++ b/policies/rpm_manifest/unsigned-rpms.rego
@@ -1,11 +1,11 @@
 package required_checks
 
-violation_image_unsigned_rpms[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  unsigned_rpms := {rpm.nvra | rpm := input.rpms[_]; not rpm.gpg}
-  not count(unsigned_rpms) == 0
+violation_image_unsigned_rpms[{"details": {"description": description, "name": name, "url": url}, "msg": msg}] if {
+	unsigned_rpms := {rpm.nvra | rpm := input.rpms[_]; not rpm.gpg}
+	not count(unsigned_rpms) == 0
 
-  name := "image_unsigned_rpms"
-  msg = sprintf("All RPMs found on the image must be signed. Found following unsigned rpms(nvra): %s", [concat(", ", unsigned_rpms)])
-  description := "Providing packages signed with the secure Red Hat signing server indicates that the package was subject to all appropriate policies and procedures."
-  url := "https://docs.engineering.redhat.com/display/PRODSEC/PSP4.0+-+Offerings+Built+Securely"
+	name := "image_unsigned_rpms"
+	msg = sprintf("All RPMs found on the image must be signed. Found following unsigned rpms(nvra): %s", [concat(", ", unsigned_rpms)])
+	description := "Providing packages signed with the secure Red Hat signing server indicates that the package was subject to all appropriate policies and procedures."
+	url := "https://docs.engineering.redhat.com/display/PRODSEC/PSP4.0+-+Offerings+Built+Securely"
 }

--- a/unittests/test_clair/vulnerabilities-check_test.rego
+++ b/unittests/test_clair/vulnerabilities-check_test.rego
@@ -2,72 +2,72 @@ package required_checks
 
 import data.clair as clair
 
-test_warn_critical_vulnerabilities {
-    result := warn_critical_vulnerabilities with input as clair
-    result[_].details.name == "clair_critical_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with critical vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+test_warn_critical_vulnerabilities if {
+	result := warn_critical_vulnerabilities with input as clair
+	result[_].details.name == "clair_critical_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with critical vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
-test_warn_unpatched_critical_vulnerabilities {
-    result := warn_unpatched_critical_vulnerabilities with input as clair
-    result[_].details.name == "clair_unpatched_critical_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
+test_warn_unpatched_critical_vulnerabilities if {
+	result := warn_unpatched_critical_vulnerabilities with input as clair
+	result[_].details.name == "clair_unpatched_critical_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
-test_warn_high_vulnerabilities {
-    result := warn_high_vulnerabilities with input as clair
-    result[_].details.name == "clair_high_vulnerabilities"
-    result[_].vulnerabilities_number == 2
-    result[_].msg == "Found packages with high vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+test_warn_high_vulnerabilities if {
+	result := warn_high_vulnerabilities with input as clair
+	result[_].details.name == "clair_high_vulnerabilities"
+	result[_].vulnerabilities_number == 2
+	result[_].msg == "Found packages with high vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
-test_warn_unpatched_high_vulnerabilities {
-    result := warn_unpatched_high_vulnerabilities with input as clair
-    result[_].details.name == "clair_unpatched_high_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
+test_warn_unpatched_high_vulnerabilities if {
+	result := warn_unpatched_high_vulnerabilities with input as clair
+	result[_].details.name == "clair_unpatched_high_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
-test_warn_medium_vulnerabilities {
-    result := warn_medium_vulnerabilities with input as clair
-    result[_].details.name == "clair_medium_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with medium vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+test_warn_medium_vulnerabilities if {
+	result := warn_medium_vulnerabilities with input as clair
+	result[_].details.name == "clair_medium_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with medium vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
-test_warn_unpatched_medium_vulnerabilities {
-    result := warn_unpatched_medium_vulnerabilities with input as clair
-    result[_].details.name == "clair_unpatched_medium_vulnerabilities"
-    result[_].vulnerabilities_number == 2
-    result[_].msg == "Found packages with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
+test_warn_unpatched_medium_vulnerabilities if {
+	result := warn_unpatched_medium_vulnerabilities with input as clair
+	result[_].details.name == "clair_unpatched_medium_vulnerabilities"
+	result[_].vulnerabilities_number == 2
+	result[_].msg == "Found packages with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
-test_warn_low_vulnerabilities {
-    result := warn_low_vulnerabilities with input as clair
-    result[_].details.name == "clair_low_vulnerabilities"
-    result[_].vulnerabilities_number == 2
-    result[_].msg == "Found packages with low/negligible vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+test_warn_low_vulnerabilities if {
+	result := warn_low_vulnerabilities with input as clair
+	result[_].details.name == "clair_low_vulnerabilities"
+	result[_].vulnerabilities_number == 2
+	result[_].msg == "Found packages with low/negligible vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
-test_warn_unpatched_low_vulnerabilities {
-    result := warn_unpatched_low_vulnerabilities with input as clair
-    result[_].details.name == "clair_unpatched_low_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with unpatched low/negligible vulnerabilities. These vulnerabilities don't have a known fix at this time."
+test_warn_unpatched_low_vulnerabilities if {
+	result := warn_unpatched_low_vulnerabilities with input as clair
+	result[_].details.name == "clair_unpatched_low_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with unpatched low/negligible vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
-test_warn_unknown_vulnerabilities {
-    result := warn_unknown_vulnerabilities with input as clair
-    result[_].details.name == "clair_unknown_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with unknown vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+test_warn_unknown_vulnerabilities if {
+	result := warn_unknown_vulnerabilities with input as clair
+	result[_].details.name == "clair_unknown_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with unknown vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
-test_warn_unpatched_unknown_vulnerabilities {
-    result := warn_unpatched_unknown_vulnerabilities with input as clair
-    result[_].details.name == "clair_unpatched_unknown_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with unpatched unknown vulnerabilities. These vulnerabilities don't have a known fix at this time."
+test_warn_unpatched_unknown_vulnerabilities if {
+	result := warn_unpatched_unknown_vulnerabilities with input as clair
+	result[_].details.name == "clair_unpatched_unknown_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with unpatched unknown vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }

--- a/unittests/test_clamav/virus-check_test.rego
+++ b/unittests/test_clamav/virus-check_test.rego
@@ -4,14 +4,12 @@ import future.keywords.in
 
 import data.clamav_output as clamav
 
-
-test_violation_infected_files {
-    result := violation_infected_files with input as clamav
-    result[_].msg == "Detected malware 'Win.Test.EICAR_HDB-1' in /tmp/test/eicar.txt"
+test_violation_infected_files if {
+	result := violation_infected_files with input as clamav
+	result[_].msg == "Detected malware 'Win.Test.EICAR_HDB-1' in /tmp/test/eicar.txt"
 }
 
-test_warn_heuristic_malware_files {
-    result := warn_heuristic_malware_files with input as clamav
-    result[_].msg == "Detected potential malware 'Heuristics.Broken.Executable' by heuristics in /work/content/usr/lib/firmware/ath11k/IPQ5018/hw1.0/m3_fw.b00.xz"
+test_warn_heuristic_malware_files if {
+	result := warn_heuristic_malware_files with input as clamav
+	result[_].msg == "Detected potential malware 'Heuristics.Broken.Executable' by heuristics in /work/content/usr/lib/firmware/ath11k/IPQ5018/hw1.0/m3_fw.b00.xz"
 }
-

--- a/unittests/test_images/deprecated-labels_test.rego
+++ b/unittests/test_images/deprecated-labels_test.rego
@@ -2,50 +2,50 @@ package required_checks
 
 import data.bad_image as image
 
-test_violation_install_deprecated {
-    result := violation_install_deprecated with input as image
-    result[_].details.name == "install_label_deprecated"
-    result[_].msg == "The INSTALL label is deprecated!"
+test_violation_install_deprecated if {
+	result := violation_install_deprecated with input as image
+	result[_].details.name == "install_label_deprecated"
+	result[_].msg == "The INSTALL label is deprecated!"
 }
 
-test_violation_architecture_deprecated {
-    result := violation_architecture_deprecated with input as image
-    result[_].details.name == "architecture_label_deprecated"
-    result[_].msg == "The Architecture label is deprecated!"
+test_violation_architecture_deprecated if {
+	result := violation_architecture_deprecated with input as image
+	result[_].details.name == "architecture_label_deprecated"
+	result[_].msg == "The Architecture label is deprecated!"
 }
 
-test_violation_name_deprecated {
-    result := violation_name_deprecated with input as image
-    result[_].details.name == "name_label_deprecated"
-    result[_].msg == "The Name label is deprecated!"
+test_violation_name_deprecated if {
+	result := violation_name_deprecated with input as image
+	result[_].details.name == "name_label_deprecated"
+	result[_].msg == "The Name label is deprecated!"
 }
 
-test_violation_release_deprecated {
-    result := violation_release_deprecated with input as image
-    result[_].details.name == "release_label_deprecated"
-    result[_].msg == "The Release label is deprecated!"
+test_violation_release_deprecated if {
+	result := violation_release_deprecated with input as image
+	result[_].details.name == "release_label_deprecated"
+	result[_].msg == "The Release label is deprecated!"
 }
 
-test_violation_uninstall_deprecated {
-    result := violation_uninstall_deprecated with input as image
-    result[_].details.name == "uninstall_label_deprecated"
-    result[_].msg == "The UNINSTALL label is deprecated!"
+test_violation_uninstall_deprecated if {
+	result := violation_uninstall_deprecated with input as image
+	result[_].details.name == "uninstall_label_deprecated"
+	result[_].msg == "The UNINSTALL label is deprecated!"
 }
 
-test_violation_version_deprecated {
-    result := violation_version_deprecated with input as image
-    result[_].details.name == "version_label_deprecated"
-    result[_].msg == "The Version label is deprecated!"
+test_violation_version_deprecated if {
+	result := violation_version_deprecated with input as image
+	result[_].details.name == "version_label_deprecated"
+	result[_].msg == "The Version label is deprecated!"
 }
 
-test_violation_bzcomponent_deprecated {
-    result := violation_bzcomponent_deprecated with input as image
-    result[_].details.name == "bzcomponent_label_deprecated"
-    result[_].msg == "The BZComponent label is deprecated!"
+test_violation_bzcomponent_deprecated if {
+	result := violation_bzcomponent_deprecated with input as image
+	result[_].details.name == "bzcomponent_label_deprecated"
+	result[_].msg == "The BZComponent label is deprecated!"
 }
 
-test_violation_run_deprecated {
-    result := violation_run_deprecated with input as image
-    result[_].details.name == "run_label_deprecated"
-    result[_].msg == "The RUN label is deprecated!"
+test_violation_run_deprecated if {
+	result := violation_run_deprecated with input as image
+	result[_].details.name == "run_label_deprecated"
+	result[_].msg == "The RUN label is deprecated!"
 }

--- a/unittests/test_images/fbc-labels_test.rego
+++ b/unittests/test_images/fbc-labels_test.rego
@@ -2,7 +2,7 @@ package fbc_checks
 
 import data.good_image as image
 
-test_violation_fbc_dc_required {
+test_violation_fbc_dc_required if {
     result := violation_fbc_dc_required with input as image
     result[_].details.name == "operators_operatorframework_io_index_configs_v1_label_required"
     result[_].msg == "The 'operators.operatorframework.io.index.configs.v1' label should be defined for FBC image"

--- a/unittests/test_images/inherited-labels_test.rego
+++ b/unittests/test_images/inherited-labels_test.rego
@@ -1,34 +1,34 @@
 package optional_checks
 
-import data.good_image as image
 import data.good_image as base_image
+import data.good_image as image
 
-test_violation_summary_label_inherited {
-    result := violation_summary_label_inherited with input as image with data.Labels as base_image.Labels
-    result[_].details.name == "summary_label_inherited"
-    result[_].msg == "The 'summary' label should not be inherited from the base image"
+test_violation_summary_label_inherited if {
+	result := violation_summary_label_inherited with input as image with data.Labels as base_image.Labels
+	result[_].details.name == "summary_label_inherited"
+	result[_].msg == "The 'summary' label should not be inherited from the base image"
 }
 
-test_violation_description_label_inherited {
-    result := violation_description_label_inherited with input as image with data.Labels as base_image.Labels
-    result[_].details.name == "description_label_inherited"
-    result[_].msg == "The 'description' label should not be inherited from the base image"
+test_violation_description_label_inherited if {
+	result := violation_description_label_inherited with input as image with data.Labels as base_image.Labels
+	result[_].details.name == "description_label_inherited"
+	result[_].msg == "The 'description' label should not be inherited from the base image"
 }
 
-test_violation_io_k8s_description_label_inherited {
-    result := violation_io_k8s_description_label_inherited with input as image with data.Labels as base_image.Labels
-    result[_].details.name == "io_k8s_description_label_inherited"
-    result[_].msg == "The 'io.k8s.description' label should not be inherited from the base image"
+test_violation_io_k8s_description_label_inherited if {
+	result := violation_io_k8s_description_label_inherited with input as image with data.Labels as base_image.Labels
+	result[_].details.name == "io_k8s_description_label_inherited"
+	result[_].msg == "The 'io.k8s.description' label should not be inherited from the base image"
 }
 
-test_violation_io_k8s_display_name_label_inherited {
-    result := violation_io_k8s_display_name_label_inherited with input as image with data.Labels as base_image.Labels
-    result[_].details.name == "io_k8s_display_name_label_inherited"
-    result[_].msg == "The 'io.k8s.display-name' label should not be inherited from the base image"
+test_violation_io_k8s_display_name_label_inherited if {
+	result := violation_io_k8s_display_name_label_inherited with input as image with data.Labels as base_image.Labels
+	result[_].details.name == "io_k8s_display_name_label_inherited"
+	result[_].msg == "The 'io.k8s.display-name' label should not be inherited from the base image"
 }
 
-test_violation_io_openshift_tags_label_inherited {
-    result := violation_io_openshift_tags_label_inherited with input as image with data.Labels as base_image.Labels
-    result[_].details.name == "io_openshift_tags_label_inherited"
-    result[_].msg == "The 'io.openshift.tags' label should not be inherited from the base image"
+test_violation_io_openshift_tags_label_inherited if {
+	result := violation_io_openshift_tags_label_inherited with input as image with data.Labels as base_image.Labels
+	result[_].details.name == "io_openshift_tags_label_inherited"
+	result[_].msg == "The 'io.openshift.tags' label should not be inherited from the base image"
 }

--- a/unittests/test_images/optional-labels_test.rego
+++ b/unittests/test_images/optional-labels_test.rego
@@ -2,14 +2,14 @@ package optional_checks
 
 import data.bad_image as image
 
-test_violation_maintainer_required {
-    result := violation_maintainer_required with input as image
-    result[_].details.name == "maintainer_label_required"
-    result[_].msg == "The 'maintainer' label should be defined"
+test_violation_maintainer_required if {
+	result := violation_maintainer_required with input as image
+	result[_].details.name == "maintainer_label_required"
+	result[_].msg == "The 'maintainer' label should be defined"
 }
 
-test_violation_summary_required {
-    result := violation_summary_required with input as image
-    result[_].details.name == "summary_label_required"
-    result[_].msg == "The 'summary' label should be defined"
+test_violation_summary_required if {
+	result := violation_summary_required with input as image
+	result[_].details.name == "summary_label_required"
+	result[_].msg == "The 'summary' label should be defined"
 }

--- a/unittests/test_images/required-labels_test.rego
+++ b/unittests/test_images/required-labels_test.rego
@@ -2,80 +2,80 @@ package required_checks
 
 import data.bad_image as image
 
-test_violation_name_required {
-    result := violation_name_required with input as image
-    result[_].details.name == "name_label_required"
-    result[_].msg == "The required 'name' label is missing!"
+test_violation_name_required if {
+	result := violation_name_required with input as image
+	result[_].details.name == "name_label_required"
+	result[_].msg == "The required 'name' label is missing!"
 }
 
-test_violation_com_redhat_component_required {
-    result := violation_com_redhat_component_required with input as image
-    result[_].details.name == "com_redhat_component_label_required!"
-    result[_].msg == "The required 'com.redhat.component' label is missing"
+test_violation_com_redhat_component_required if {
+	result := violation_com_redhat_component_required with input as image
+	result[_].details.name == "com_redhat_component_label_required!"
+	result[_].msg == "The required 'com.redhat.component' label is missing"
 }
 
-test_violation_version_required {
-    result := violation_version_required with input as image
-    result[_].details.name == "version_label_required"
-    result[_].msg == "The required 'version' label is missing!"
+test_violation_version_required if {
+	result := violation_version_required with input as image
+	result[_].details.name == "version_label_required"
+	result[_].msg == "The required 'version' label is missing!"
 }
 
-test_violation_description_required {
-    result := violation_description_required with input as image
-    result[_].details.name == "description_label_required"
-    result[_].msg == "The required 'description' label is missing!"
+test_violation_description_required if {
+	result := violation_description_required with input as image
+	result[_].details.name == "description_label_required"
+	result[_].msg == "The required 'description' label is missing!"
 }
 
-test_violation_io_k8s_description_required {
-    result := violation_io_k8s_description_required with input as image
-    result[_].details.name == "io_k8s_description_label_required"
-    result[_].msg == "The required 'io.k8s.description' label is missing!"
+test_violation_io_k8s_description_required if {
+	result := violation_io_k8s_description_required with input as image
+	result[_].details.name == "io_k8s_description_label_required"
+	result[_].msg == "The required 'io.k8s.description' label is missing!"
 }
 
-test_violation_vcs_ref_required {
-    result := violation_vcs_ref_required with input as image
-    result[_].details.name == "vcs_ref_label_required"
-    result[_].msg == "The required 'vcs-ref' label is missing!"
+test_violation_vcs_ref_required if {
+	result := violation_vcs_ref_required with input as image
+	result[_].details.name == "vcs_ref_label_required"
+	result[_].msg == "The required 'vcs-ref' label is missing!"
 }
 
-test_violation_vcs_type_required {
-    result := violation_vcs_type_required with input as image
-    result[_].details.name == "vcs_type_label_required"
-    result[_].msg == "The required 'vcs-type' label is missing!"
+test_violation_vcs_type_required if {
+	result := violation_vcs_type_required with input as image
+	result[_].details.name == "vcs_type_label_required"
+	result[_].msg == "The required 'vcs-type' label is missing!"
 }
 
-test_violation_architecture_required {
-    result := violation_architecture_required with input as image
-    result[_].details.name == "architecture_label_required"
-    result[_].msg == "The required 'architecture' label is missing!"
+test_violation_architecture_required if {
+	result := violation_architecture_required with input as image
+	result[_].details.name == "architecture_label_required"
+	result[_].msg == "The required 'architecture' label is missing!"
 }
 
-test_violation_vendor_required {
-    result := violation_vendor_required with input as image
-    result[_].details.name == "vendor_label_required"
-    result[_].msg == "The required 'vendor' label is missing!"
+test_violation_vendor_required if {
+	result := violation_vendor_required with input as image
+	result[_].details.name == "vendor_label_required"
+	result[_].msg == "The required 'vendor' label is missing!"
 }
 
-test_violation_release_required {
-    result := violation_release_required with input as image
-    result[_].details.name == "release_label_required"
-    result[_].msg == "The required 'release' label is missing!"
+test_violation_release_required if {
+	result := violation_release_required with input as image
+	result[_].details.name == "release_label_required"
+	result[_].msg == "The required 'release' label is missing!"
 }
 
-test_violation_url_required {
-    result := violation_url_required with input as image
-    result[_].details.name == "url_label_required"
-    result[_].msg == "The required 'url' label is missing!"
+test_violation_url_required if {
+	result := violation_url_required with input as image
+	result[_].details.name == "url_label_required"
+	result[_].msg == "The required 'url' label is missing!"
 }
 
-test_violation_build_date_required {
-    result := violation_build_date_required with input as image
-    result[_].details.name == "build_date_label_required"
-    result[_].msg == "The required 'build-date' label is missing!"
+test_violation_build_date_required if {
+	result := violation_build_date_required with input as image
+	result[_].details.name == "build_date_label_required"
+	result[_].msg == "The required 'build-date' label is missing!"
 }
 
-test_violation_distribution_scope_required {
-    result := violation_distribution_scope_required with input as image
-    result[_].details.name == "distribution_scope_label_required"
-    result[_].msg == "The required 'distribution-scope' label is missing!"
+test_violation_distribution_scope_required if {
+	result := violation_distribution_scope_required with input as image
+	result[_].details.name == "distribution_scope_label_required"
+	result[_].msg == "The required 'distribution-scope' label is missing!"
 }

--- a/unittests/test_repository/deprecated-image_test.rego
+++ b/unittests/test_repository/deprecated-image_test.rego
@@ -2,9 +2,9 @@ package required_checks
 
 import data.repository as repository
 
-test_violation_image_repository_deprecated {
-    result := violation_image_repository_deprecated with input as repository
-    result[_].details.name == "image_repository_deprecated"
-    result[_].msg == "The container image shouldn't be built from a repository that is marked as 'Deprecated' in Red Hat Catalog."
-    result[_].details.url == "https://redhat-connect.gitbook.io/catalog-help/container-images/container-image-details/container-image-release-categories"
+test_violation_image_repository_deprecated if {
+	result := violation_image_repository_deprecated with input as repository
+	result[_].details.name == "image_repository_deprecated"
+	result[_].msg == "The container image shouldn't be built from a repository that is marked as 'Deprecated' in Red Hat Catalog."
+	result[_].details.url == "https://redhat-connect.gitbook.io/catalog-help/container-images/container-image-details/container-image-release-categories"
 }

--- a/unittests/test_rpm_manifest/unsigned-rpm_test.rego
+++ b/unittests/test_rpm_manifest/unsigned-rpm_test.rego
@@ -2,8 +2,8 @@ package required_checks
 
 import data.rpm_manifest as rpm_manifest
 
-test_violation_image_unsigned_rpms {
-    result := violation_image_unsigned_rpms with input as rpm_manifest
-    result[_].details.name == "image_unsigned_rpms"
-    result[_].msg == "All RPMs found on the image must be signed. Found following unsigned rpms(nvra): perl-File-Path-2.09-2.el7.noarch"
+test_violation_image_unsigned_rpms if {
+	result := violation_image_unsigned_rpms with input as rpm_manifest
+	result[_].details.name == "image_unsigned_rpms"
+	result[_].msg == "All RPMs found on the image must be signed. Found following unsigned rpms(nvra): perl-File-Path-2.09-2.el7.noarch"
 }


### PR DESCRIPTION
Slack thread
https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1756837143866999
Clamav is failing on:
`Error: running test: load: loading policies: load: 5 errors occurred during loading:
/project/clamav/virus-check.rego:5: rego_parse_error: `if` keyword is required before rule body
/project/clamav/virus-check.rego:5: rego_parse_error: `contains` keyword is required for partial set rules
/project/clamav/virus-check.rego:16: rego_parse_error: `if` keyword is required before rule body
/project/clamav/virus-check.rego:16: rego_parse_error: `contains` keyword is required for partial set rules
/project/clamav/virus-check.rego:27: rego_parse_error: `if` keyword is required before rule body`

Most probably caused by incompatibility with OPA.