### PR TITLE
fix: handle multiple warn/violations

### DIFF
--- a/policies/clair/vulnerabilities-check.rego
+++ b/policies/clair/vulnerabilities-check.rego
@@ -33,7 +33,7 @@ generate_description(vulnerabilities) := dsc if {
                  )])
 }
 
-warn_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+warn_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
   rpms_with_critical_vulnerabilities := get_patched_vulnerabilities(input, "Critical")
   not count(rpms_with_critical_vulnerabilities) == 0
 
@@ -42,9 +42,9 @@ warn_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_n
   msg := "Found packages with critical vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
   description := generate_description(rpms_with_critical_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
-}
+]
 
-warn_unpatched_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+warn_unpatched_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
   rpms_with_unpatched_critical_vulnerabilities := get_unpatched_vulnerabilities(input, "Critical")
   not count(rpms_with_unpatched_critical_vulnerabilities) == 0
 
@@ -53,9 +53,9 @@ warn_unpatched_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number
   msg := "Found packages with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
   description := generate_description(rpms_with_unpatched_critical_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
-}
+]
 
-warn_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+warn_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
   rpms_with_high_vulnerabilities := get_patched_vulnerabilities(input, "High")
   not count(rpms_with_high_vulnerabilities) == 0
 
@@ -64,9 +64,9 @@ warn_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, 
   msg := "Found packages with high vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
   description := generate_description(rpms_with_high_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
-}
+]
 
-warn_unpatched_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+warn_unpatched_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
   rpms_with_unpatched_high_vulnerabilities := get_unpatched_vulnerabilities(input, "High")
   not count(rpms_with_unpatched_high_vulnerabilities) == 0
 
@@ -75,9 +75,9 @@ warn_unpatched_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": v
   msg := "Found packages with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
   description := generate_description(rpms_with_unpatched_high_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
-}
+]
 
-warn_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+warn_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
   rpms_with_medium_vulnerabilities := get_patched_vulnerabilities(input, "Medium")
   not count(rpms_with_medium_vulnerabilities) == 0
 
@@ -86,9 +86,9 @@ warn_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num
   msg := "Found packages with medium vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
   description := generate_description(rpms_with_medium_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
-}
+]
 
-warn_unpatched_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+warn_unpatched_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
   rpms_with_unpatched_medium_vulnerabilities := get_unpatched_vulnerabilities(input, "Medium")
   not count(rpms_with_unpatched_medium_vulnerabilities) == 0
 
@@ -97,9 +97,9 @@ warn_unpatched_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number":
   msg := "Found packages with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
   description := generate_description(rpms_with_unpatched_medium_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
-}
+]
 
-warn_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+warn_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
   rpms_with_low_vulnerabilities := get_patched_vulnerabilities(input, "Low")
   rpms_with_negligible_vulnerabilities := get_patched_vulnerabilities(input, "Negligible")
   rpms_with_low_neg_vulnerabilities = array.concat(rpms_with_low_vulnerabilities, rpms_with_negligible_vulnerabilities)
@@ -110,9 +110,9 @@ warn_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "
   msg := "Found packages with low/negligible vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
   description := generate_description(rpms_with_low_neg_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
-}
+]
 
-warn_unpatched_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+warn_unpatched_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
   rpms_with_unpatched_low_vulnerabilities := get_unpatched_vulnerabilities(input, "Low")
   rpms_with_unpatched_negligible_vulnerabilities := get_unpatched_vulnerabilities(input, "Negligible")
   rpms_with_unpatched_low_neg_vulnerabilities = array.concat(rpms_with_unpatched_low_vulnerabilities, rpms_with_unpatched_negligible_vulnerabilities)
@@ -123,9 +123,9 @@ warn_unpatched_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vu
   msg := "Found packages with unpatched low/negligible vulnerabilities. These vulnerabilities don't have a known fix at this time."
   description := generate_description(rpms_with_unpatched_low_neg_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
-}
+]
 
-warn_unknown_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+warn_unknown_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
   rpms_with_unknown_vulnerabilities := get_patched_vulnerabilities(input, "Unknown")
   not count(rpms_with_unknown_vulnerabilities) == 0
 
@@ -134,9 +134,9 @@ warn_unknown_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_nu
   msg := "Found packages with unknown vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
   description := generate_description(rpms_with_unknown_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
-}
+]
 
-warn_unpatched_unknown_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] if {
+warn_unpatched_unknown_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
   rpms_with_unpatched_unknown_vulnerabilities := get_unpatched_vulnerabilities(input, "Unknown")
   not count(rpms_with_unpatched_unknown_vulnerabilities) == 0
 
@@ -145,4 +145,4 @@ warn_unpatched_unknown_vulnerabilities := [{"msg": msg, "vulnerabilities_number"
   msg := "Found packages with unpatched unknown vulnerabilities. These vulnerabilities don't have a known fix at this time."
   description := generate_description(rpms_with_unpatched_unknown_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
-}
+]

--- a/policies/clamav/virus-check.rego
+++ b/policies/clamav/virus-check.rego
@@ -3,7 +3,7 @@ package required_checks
 import future.keywords.in
 import future.keywords.if
 
-violation_infected_files := [{"msg": msg, "details": {"filename": filename, "virname": virname, "description": description}}] if {
+violation_infected_files := [{"msg": msg, "details": {"filename": filename, "virname": virname, "description": description}} |
 	hit := _report.hits[_]
 
 	filename := hit.filename
@@ -12,9 +12,9 @@ violation_infected_files := [{"msg": msg, "details": {"filename": filename, "vir
 	description := "A malware has been found."
 
 	not hit.is_heuristic # we don't want heursitics checks to cause false positive failures
-}
+]
 
-warn_heuristic_malware_files := [{"msg": msg, "details": {"filename": filename, "virname": virname, "description": description}}] if {
+warn_heuristic_malware_files := [{"msg": msg, "details": {"filename": filename, "virname": virname, "description": description}} |
 	hit := _report.hits[_]
 
 	filename := hit.filename
@@ -23,7 +23,7 @@ warn_heuristic_malware_files := [{"msg": msg, "details": {"filename": filename, 
 	description := "The heuristic check detected a potential malware. (Heuristic checks have higher possibility of false positive results.)"
 
 	hit.is_heuristic # we want to only warn for heuristic checks
-}
+]
 
 _report := d if {
 	marker := "----------- SCAN SUMMARY -----------"

--- a/policies/image/deprecated-labels.rego
+++ b/policies/image/deprecated-labels.rego
@@ -1,75 +1,73 @@
 package required_checks
 
-import future.keywords.if
-
-violation_install_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_install_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["INSTALL"]
 
   name := "install_label_deprecated"
   msg := "The INSTALL label is deprecated!"
   description := "The 'INSTALL' label is deprecated, replace with 'install'"
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_architecture_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_architecture_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["Architecture"]
 
   name := "architecture_label_deprecated"
   msg := "The Architecture label is deprecated!"
   description := "The 'Architecture' label is deprecated, replace with 'architecture'"
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_name_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_name_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["Name"]
 
   name := "name_label_deprecated"
   msg := "The Name label is deprecated!"
   description := "The 'Name' label is deprecated, replace with 'name'"
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_release_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_release_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["Release"]
 
   name := "release_label_deprecated"
   msg := "The Release label is deprecated!"
   description := "The 'Release' label is deprecated, replace with 'release'"
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_uninstall_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_uninstall_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["UNINSTALL"]
 
   name := "uninstall_label_deprecated"
   msg := "The UNINSTALL label is deprecated!"
   description := "The 'UNINSTALL' label is deprecated, replace with 'uninstall'"
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_version_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_version_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["Version"]
 
   name := "version_label_deprecated"
   msg := "The Version label is deprecated!"
   description := "The 'Version' label is deprecated, replace with 'version'"
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_bzcomponent_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_bzcomponent_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["BZComponent"]
 
   name := "bzcomponent_label_deprecated"
   msg := "The BZComponent label is deprecated!"
   description := "The BZComponent label is deprecated, replace with 'com.redhat.component'"
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_run_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_run_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["RUN"]
 
   name := "run_label_deprecated"
   msg := "The RUN label is deprecated!"
   description := "The 'RUN' label is deprecated, replace with 'run'"
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]

--- a/policies/image/fbc-labels.rego
+++ b/policies/image/fbc-labels.rego
@@ -1,12 +1,10 @@
 package fbc_checks
 
-import future.keywords.if
-
-violation_fbc_dc_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_fbc_dc_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["operators.operatorframework.io.index.configs.v1"]
 
   name := "operators_operatorframework_io_index_configs_v1_label_required"
   msg := "The 'operators.operatorframework.io.index.configs.v1' label should be defined for FBC image"
   description := "Should set DC-specific label `operators.operatorframework.io.index.configs.v1` for the location of the DC root directory for FBC image."
   url := "https://docs.openshift.com/container-platform/4.9/operators/admin/olm-managing-custom-catalogs.html#olm-creating-fb-catalog-image_olm-managing-custom-catalogs"
-}
+]

--- a/policies/image/inherited-labels.rego
+++ b/policies/image/inherited-labels.rego
@@ -1,49 +1,48 @@
 package optional_checks
 
 import data as base_image
-import future.keywords.if
 
-violation_summary_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_summary_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["summary"] == base_image.Labels["summary"]
 
   name := "summary_label_inherited"
   msg := "The 'summary' label should not be inherited from the base image"
   description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
-}
+]
 
-violation_description_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_description_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["description"] == base_image.Labels["description"]
 
   name := "description_label_inherited"
   msg := "The 'description' label should not be inherited from the base image"
   description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
-}
+]
 
-violation_io_k8s_description_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_io_k8s_description_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["io.k8s.description"] == base_image.Labels["io.k8s.description"]
 
   name := "io_k8s_description_label_inherited"
   msg := "The 'io.k8s.description' label should not be inherited from the base image"
   description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
-}
+]
 
-violation_io_k8s_display_name_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_io_k8s_display_name_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["io.k8s.display-name"] == base_image.Labels["io.k8s.display-name"]
 
   name := "io_k8s_display_name_label_inherited"
   msg := "The 'io.k8s.display-name' label should not be inherited from the base image"
   description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
-}
+]
 
-violation_io_openshift_tags_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_io_openshift_tags_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.Labels["io.openshift.tags"] == base_image.Labels["io.openshift.tags"]
 
   name := "io_openshift_tags_label_inherited"
   msg := "The 'io.openshift.tags' label should not be inherited from the base image"
   description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
-}
+]

--- a/policies/image/optional-labels.rego
+++ b/policies/image/optional-labels.rego
@@ -1,21 +1,20 @@
 package optional_checks
 
-import future.keywords.if
 
-violation_maintainer_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_maintainer_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["maintainer"]
 
   name := "maintainer_label_required"
   msg := "The 'maintainer' label should be defined"
   description := "The name and email of the maintainer (usually the submitter). Should contain `@redhat.com` or `Red Hat`."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_summary_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_summary_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["summary"]
 
   name := "summary_label_required"
   msg := "The 'summary' label should be defined"
   description := "A short description of the image."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]

--- a/policies/image/required-labels.rego
+++ b/policies/image/required-labels.rego
@@ -1,120 +1,119 @@
 package required_checks
 
-import future.keywords.if
 
-violation_name_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_name_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["name"]
 
   name := "name_label_required"
   msg := "The required 'name' label is missing!"
   description := "Name of the Image or Container."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_com_redhat_component_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_com_redhat_component_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["com.redhat.component"]
 
   name := "com_redhat_component_label_required!"
   msg := "The required 'com.redhat.component' label is missing"
   description := "The Bugzilla component name where bugs against this container should be reported by users."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_version_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_version_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["version"]
 
   name := "version_label_required"
   msg := "The required 'version' label is missing!"
   description := "Version of the image."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_description_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_description_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["description"]
 
   name := "description_label_required"
   msg := "The required 'description' label is missing!"
   description := "Detailed description of the image."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_io_k8s_description_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_io_k8s_description_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["io.k8s.description"]
 
   name := "io_k8s_description_label_required"
   msg := "The required 'io.k8s.description' label is missing!"
   description := "Description of the container displayed in Kubernetes."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_vcs_ref_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_vcs_ref_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["vcs-ref"]
 
   name := "vcs_ref_label_required"
   msg := "The required 'vcs-ref' label is missing!"
   description := "A 'reference' within the version control repository; e.g. a git commit, or a subversion branch."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_vcs_type_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_vcs_type_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["vcs-type"]
 
   name := "vcs_type_label_required"
   msg := "The required 'vcs-type' label is missing!"
   description := "The type of version control used by the container source. Generally one of git, hg, svn, bzr, cvs"
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_architecture_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_architecture_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["architecture"]
 
   name := "architecture_label_required"
   msg := "The required 'architecture' label is missing!"
   description := "Architecture the software in the image should target."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_vendor_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_vendor_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["vendor"]
 
   name := "vendor_label_required"
   msg := "The required 'vendor' label is missing!"
   description := "Name of the vendor."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_release_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_release_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["release"]
 
   name := "release_label_required"
   msg := "The required 'release' label is missing!"
   description := "Release Number for this version."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_url_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_url_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["url"]
 
   name := "url_label_required"
   msg := "The required 'url' label is missing!"
   description := "A URL where the user can find more information about the image."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_build_date_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_build_date_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["build-date"]
 
   name := "build_date_label_required"
   msg := "The required 'build-date' label is missing!"
   description := "Date/Time image was built as RFC 3339 date-time."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]
 
-violation_distribution_scope_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_distribution_scope_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   not input.Labels["distribution-scope"]
 
   name := "distribution_scope_label_required"
   msg := "The required 'distribution-scope' label is missing!"
   description := "Scope of intended distribution of the image. (private/authoritative-source-only/restricted/public)."
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
+]

--- a/policies/repository/deprecated-image.rego
+++ b/policies/repository/deprecated-image.rego
@@ -1,12 +1,11 @@
 package required_checks
 
-import future.keywords.if
 
-violation_image_repository_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_image_repository_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   input.release_categories[_] == "Deprecated"
 
   name := "image_repository_deprecated"
   msg := "The container image shouldn't be built from a repository that is marked as 'Deprecated' in Red Hat Catalog."
   description := "Deprecated images are no longer maintained and will accumulate security vulnerabilities without releasing a fixed version."
   url := "https://redhat-connect.gitbook.io/catalog-help/container-images/container-image-details/container-image-release-categories"
-}
+]

--- a/policies/rpm_manifest/unsigned-rpms.rego
+++ b/policies/rpm_manifest/unsigned-rpms.rego
@@ -1,8 +1,7 @@
 package required_checks
 
-import future.keywords.if
 
-violation_image_unsigned_rpms := [{"msg": msg, "details":{"name": name, "description": description, "url": url}}] if {
+violation_image_unsigned_rpms := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
   unsigned_rpms := {rpm.nvra | rpm := input.rpms[_]; not rpm.gpg}
   not count(unsigned_rpms) == 0
 
@@ -10,4 +9,4 @@ violation_image_unsigned_rpms := [{"msg": msg, "details":{"name": name, "descrip
   msg = sprintf("All RPMs found on the image must be signed. Found following unsigned rpms(nvra): %s", [concat(", ", unsigned_rpms)])
   description := "Providing packages signed with the secure Red Hat signing server indicates that the package was subject to all appropriate policies and procedures."
   url := "https://docs.engineering.redhat.com/display/PRODSEC/PSP4.0+-+Offerings+Built+Securely"
-}
+]

--- a/unittests/test_clamav/virus-check_test.rego
+++ b/unittests/test_clamav/virus-check_test.rego
@@ -13,6 +13,7 @@ test_violation_infected_files if {
 
 test_warn_heuristic_malware_files if {
     result := warn_heuristic_malware_files with input as clamav
-    result[_].msg == "Detected potential malware 'Heuristics.Broken.Executable' by heuristics in /work/content/usr/lib/firmware/ath11k/IPQ5018/hw1.0/m3_fw.b00.xz"
+    result[0].msg == "Detected potential malware 'Heuristics.Limits.Exceeded.MaxFileSize' by heuristics in /tmp/giant-file.a"
+    result[1].msg == "Detected potential malware 'Heuristics.Limits.Exceeded.MaxFileSize' by heuristics in /tmp/giant.db"
+    result[2].msg == "Detected potential malware 'Heuristics.Broken.Executable' by heuristics in /work/content/usr/lib/firmware/ath11k/IPQ5018/hw1.0/m3_fw.b00.xz"
 }
-

--- a/unittests/test_data/clamav.yaml
+++ b/unittests/test_data/clamav.yaml
@@ -1,5 +1,7 @@
 clamav_output:
   output: |
+    /tmp/giant-file.a: Heuristics.Limits.Exceeded.MaxFileSize FOUND
+    /tmp/giant.db: Heuristics.Limits.Exceeded.MaxFileSize FOUND
     /tmp/test/eicar.txt: Win.Test.EICAR_HDB-1 FOUND
     /work/content/usr/lib/firmware/ath11k/IPQ5018/hw1.0/m3_fw.b00.xz: Heuristics.Broken.Executable FOUND
     A random debug output

--- a/unittests/test_images/deprecated-labels_test.rego
+++ b/unittests/test_images/deprecated-labels_test.rego
@@ -1,7 +1,8 @@
 package required_checks
 
-import data.bad_image as image
 import future.keywords.if
+
+import data.bad_image as image
 
 test_violation_install_deprecated if {
     result := violation_install_deprecated with input as image

--- a/unittests/test_images/fbc-labels_test.rego
+++ b/unittests/test_images/fbc-labels_test.rego
@@ -1,7 +1,8 @@
 package fbc_checks
 
-import data.good_image as image
 import future.keywords.if
+
+import data.good_image as image
 
 test_violation_fbc_dc_required if {
     result := violation_fbc_dc_required with input as image

--- a/unittests/test_images/inherited-labels_test.rego
+++ b/unittests/test_images/inherited-labels_test.rego
@@ -1,8 +1,9 @@
 package optional_checks
 
+import future.keywords.if
+
 import data.good_image as image
 import data.good_image as base_image
-import future.keywords.if
 
 test_violation_summary_label_inherited if {
     result := violation_summary_label_inherited with input as image with data.Labels as base_image.Labels

--- a/unittests/test_images/optional-labels_test.rego
+++ b/unittests/test_images/optional-labels_test.rego
@@ -1,7 +1,8 @@
 package optional_checks
 
-import data.bad_image as image
 import future.keywords.if
+
+import data.bad_image as image
 
 test_violation_maintainer_required if {
     result := violation_maintainer_required with input as image

--- a/unittests/test_images/required-labels_test.rego
+++ b/unittests/test_images/required-labels_test.rego
@@ -1,7 +1,8 @@
 package required_checks
 
-import data.bad_image as image
 import future.keywords.if
+
+import data.bad_image as image
 
 test_violation_name_required if {
     result := violation_name_required with input as image

--- a/unittests/test_repository/deprecated-image_test.rego
+++ b/unittests/test_repository/deprecated-image_test.rego
@@ -1,7 +1,8 @@
 package required_checks
 
-import data.repository as repository
 import future.keywords.if
+
+import data.repository as repository
 
 test_violation_image_repository_deprecated if {
     result := violation_image_repository_deprecated with input as repository

--- a/unittests/test_rpm_manifest/unsigned-rpm_test.rego
+++ b/unittests/test_rpm_manifest/unsigned-rpm_test.rego
@@ -1,7 +1,8 @@
 package required_checks
 
-import data.rpm_manifest as rpm_manifest
 import future.keywords.if
+
+import data.rpm_manifest as rpm_manifest
 
 test_violation_image_unsigned_rpms if {
     result := violation_image_unsigned_rpms with input as rpm_manifest


### PR DESCRIPTION
The previous fix turned out to be a band-aid since the tests only contained single warnings/violations.  The syntax has been updated to an array comprehension to collect all hits.

I've added a `virus-check.rego` test with multiple entries, but other tests should probably have additional test cases also in the future.

Slack thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1757379392336739
ref: https://issues.redhat.com/browse/KFLUXSPRT-5012