### PR TITLE
feat(STONEINTG-1587): update rego policies for CVE-oriented ACS output

### DIFF
--- a/policies/roxctl/vulnerabilities-check.rego
+++ b/policies/roxctl/vulnerabilities-check.rego
@@ -1,55 +1,69 @@
 package required_checks
 
 import future.keywords.if
+import future.keywords.in
 
-# Severity mapping for roxctl
-# CRITICAL -> Critical
-# IMPORTANT -> High  
-# MODERATE -> Medium
-# LOW -> Low
+# Severity mapping for roxctl (CVE-oriented format)
+# CRITICAL_VULNERABILITY_SEVERITY -> Critical
+# IMPORTANT_VULNERABILITY_SEVERITY -> High
+# MODERATE_VULNERABILITY_SEVERITY -> Medium
+# LOW_VULNERABILITY_SEVERITY -> Low
 
-# Function to get components with vulnerabilities of specific severity that have fixes
+roxctl_has_rhsa_advisory(advisories) if {
+  some a in advisories
+  contains(a.name, "RHSA")
+}
+
 roxctl_get_patched_vulnerabilities(input_data, severity) := vulnerabilities if {
-  vulnerabilities := [{"name": v.componentName, "version": v.componentVersion, "vulnerabilities": vuln} |
-    v := input_data.result.vulnerabilities[_]
-    vuln := {v.cveId | v.cveSeverity == severity; v.componentFixedVersion != ""; contains(v.advisoryId,"RHSA"); v.cveInfo != ""; contains(v.cveInfo,"redhat")}
-    count(vuln) > 0
+  vulnerabilities := [entry |
+    v := input_data[_]
+    v.severity == severity
+    v.fixedBy != ""
+    count(v.advisory) > 0
+    roxctl_has_rhsa_advisory(v.advisory)
+    entry := {"cve": v.cve, "components": v.components, "fixedBy": v.fixedBy}
   ]
 }
 
-# Function to get components with vulnerabilities of specific severity without fixes
 roxctl_get_unpatched_vulnerabilities(input_data, severity) := vulnerabilities if {
-  vulnerabilities := [{"name": v.componentName, "version": v.componentVersion, "vulnerabilities": vuln} |
-    v := input_data.result.vulnerabilities[_]
-    vuln := {v.cveId | v.cveSeverity == severity; v.componentFixedVersion == ""; not contains(v.advisoryId,"RHSA")}
-    count(vuln) > 0
+  vulnerabilities := [entry |
+    v := input_data[_]
+    v.severity == severity
+    v.fixedBy == ""
+    count(v.advisory) == 0
+    entry := {"cve": v.cve, "components": v.components}
   ]
 }
 
-# Function to get all cves with discrepancies
 roxctl_get_discrepancies(input_data) := disc if {
-  disc := [{"name": v.componentName, "version": v.componentVersion, "vulnerabilities": vuln} |
-    v := input_data.result.vulnerabilities[_]
-    vuln := {v.cveId | v.cveInfo == ""; not contains(v.cveInfo,"redhat")}
-    count(vuln) > 0
+  disc := [entry |
+    v := input_data[_]
+    v.severity != ""
+    not roxctl_has_redhat_link(v.links)
+    entry := {"cve": v.cve, "components": v.components, "links": v.links}
   ]
 }
 
-# Function returns count of all vulnerabilities
-roxctl_count_vulnerabilities(vulnerabilities) := cnt if {
-  cnt := sum([count(v.vulnerabilities) | v := vulnerabilities[_]])
+roxctl_has_redhat_link(links) if {
+  some link in links
+  contains(link, "redhat")
 }
 
-# Function generates description with components and their vulnerabilities
+roxctl_count_vulnerabilities(vulnerabilities) := count(vulnerabilities)
+
+roxctl_format_components(components) := formatted if {
+  formatted := concat(", ", [sprintf("%s-%s@%s", [c.component, c.version, c.source]) | c := components[_]])
+}
+
 roxctl_generate_description(vulnerabilities) := dsc if {
   dsc := sprintf("Vulnerabilities found: %s", [concat(", ",
-                  [sprintf("%s-%s@%s (%s)", [v.name, v.version, v.location, concat(", ", v.vulnerabilities)]) | v := vulnerabilities[_]]
-                )])
+    [sprintf("%s: %s", [v.cve, roxctl_format_components(v.components)]) | v := vulnerabilities[_]]
+  )])
 }
 
 
 warn_roxctl_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_critical_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "CRITICAL")
+  components_with_critical_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "CRITICAL_VULNERABILITY_SEVERITY")
   not count(components_with_critical_vulnerabilities) == 0
 
   name := "roxctl_critical_vulnerabilities"
@@ -60,7 +74,7 @@ warn_roxctl_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": 
 ]
 
 warn_roxctl_unpatched_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_unpatched_critical_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "CRITICAL")
+  components_with_unpatched_critical_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "CRITICAL_VULNERABILITY_SEVERITY")
   not count(components_with_unpatched_critical_vulnerabilities) == 0
 
   name := "roxctl_unpatched_critical_vulnerabilities"
@@ -71,7 +85,7 @@ warn_roxctl_unpatched_critical_vulnerabilities := [{"msg": msg, "vulnerabilities
 ]
 
 warn_roxctl_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_high_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "IMPORTANT")
+  components_with_high_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "IMPORTANT_VULNERABILITY_SEVERITY")
   not count(components_with_high_vulnerabilities) == 0
 
   name := "roxctl_high_vulnerabilities"
@@ -82,7 +96,7 @@ warn_roxctl_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vuln
 ]
 
 warn_roxctl_unpatched_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_unpatched_high_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "IMPORTANT")
+  components_with_unpatched_high_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "IMPORTANT_VULNERABILITY_SEVERITY")
   not count(components_with_unpatched_high_vulnerabilities) == 0
 
   name := "roxctl_unpatched_high_vulnerabilities"
@@ -93,7 +107,7 @@ warn_roxctl_unpatched_high_vulnerabilities := [{"msg": msg, "vulnerabilities_num
 ]
 
 warn_roxctl_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_medium_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "MODERATE")
+  components_with_medium_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "MODERATE_VULNERABILITY_SEVERITY")
   not count(components_with_medium_vulnerabilities) == 0
 
   name := "roxctl_medium_vulnerabilities"
@@ -104,7 +118,7 @@ warn_roxctl_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vu
 ]
 
 warn_roxctl_unpatched_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_unpatched_medium_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "MODERATE")
+  components_with_unpatched_medium_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "MODERATE_VULNERABILITY_SEVERITY")
   not count(components_with_unpatched_medium_vulnerabilities) == 0
 
   name := "roxctl_unpatched_medium_vulnerabilities"
@@ -115,7 +129,7 @@ warn_roxctl_unpatched_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_n
 ]
 
 warn_roxctl_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_low_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "LOW")
+  components_with_low_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "LOW_VULNERABILITY_SEVERITY")
   not count(components_with_low_vulnerabilities) == 0
 
   name := "roxctl_low_vulnerabilities"
@@ -126,7 +140,7 @@ warn_roxctl_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns
 ]
 
 warn_roxctl_unpatched_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_unpatched_low_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "LOW")
+  components_with_unpatched_low_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "LOW_VULNERABILITY_SEVERITY")
   not count(components_with_unpatched_low_vulnerabilities) == 0
 
   name := "roxctl_unpatched_low_vulnerabilities"

--- a/unittests/test_data/roxctl_new.json
+++ b/unittests/test_data/roxctl_new.json
@@ -1,687 +1,211 @@
 {
-  "roxctl_new":{
-  "result": {
-    "summary": {
-      "CRITICAL": 2,
-      "IMPORTANT": 2,
-      "LOW": 28,
-      "MODERATE": 15,
-      "TOTAL-COMPONENTS": 24,
-      "TOTAL-VULNERABILITIES": 46
+  "roxctl_new": [
+    {
+      "cve": "CVE-2025-60753",
+      "advisory": [
+        {
+          "name": "RHSA-2025:20936",
+          "link": "https://access.redhat.com/errata/RHSA-2025:20936"
+        },
+        {
+          "name": "RHSA-2025:20937",
+          "link": "https://access.redhat.com/errata/RHSA-2025:20937"
+        }
+      ],
+      "summary": "A critical vulnerability in libarchive.",
+      "links": [
+        "https://access.redhat.com/security/cve/CVE-2025-60753"
+      ],
+      "fixedBy": "0:3.5.3-6.el9_6",
+      "severity": "CRITICAL_VULNERABILITY_SEVERITY",
+      "components": [
+        {
+          "component": "libarchive",
+          "version": "3.5.3-5.el9_6",
+          "source": "var/lib/rpm"
+        }
+      ]
     },
-    "vulnerabilities": [
-      {
-        "cveId": "CVE-2025-5914",
-        "cveSeverity": "IMPORTANT",
-        "cveCVSS": 7.3,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-5914",
-        "advisoryId": "RHSA-2025:14130",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:14130",
-        "componentName": "libarchive",
-        "componentVersion": "3.5.3-5.el9_6",
-        "componentFixedVersion": "0:3.5.3-6.el9_6"
-      },
-      {
-        "cveId": "CVE-2025-60753",
-        "cveSeverity": "CRITICAL",
-        "cveCVSS": 5.5,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-60753",
-        "advisoryId": "RHSA-2025:20936",
-        "advisoryInfo": "",
-        "componentName": "libarchive",
-        "componentVersion": "3.5.3-5.el9_6",
-        "componentFixedVersion": "0:3.5.3-6.el9_6"
-      },
-      {
-        "cveId": "CVE-2023-30571",
-        "cveSeverity": "CRITICAL",
-        "cveCVSS": 5.3,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2023-30571",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libarchive",
-        "componentVersion": "3.5.3-5.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-5918",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.9,
-        "cveInfo": "",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libarchive1",
-        "componentVersion": "3.5.3-5.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-5917",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.9,
-        "cveInfo": "https://not.a.redh.com",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libarchive2",
-        "componentVersion": "3.5.3-5.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-5916",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.9,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-5916",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libarchive",
-        "componentVersion": "3.5.3-5.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-5915",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.9,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-5915",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libarchive",
-        "componentVersion": "3.5.3-5.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-5918",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.9,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-5918",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libarchive",
-        "componentVersion": "3.5.3-5.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-1632",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.3,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-1632",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libarchive",
-        "componentVersion": "3.5.3-5.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-5917",
-        "cveSeverity": "LOW",
-        "cveCVSS": 2.8,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-5917",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libarchive",
-        "componentVersion": "3.5.3-5.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-6965",
-        "cveSeverity": "IMPORTANT",
-        "cveCVSS": 7.7,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-6965",
-        "advisoryId": "RHSA-2025:20936",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:20936",
-        "componentName": "sqlite-libs",
-        "componentVersion": "3.34.1-8.el9_6",
-        "componentFixedVersion": ""
-      },
-       {
-        "cveId": "CVE-2025-6966",
-        "cveSeverity": "IMPORTANT",
-        "cveCVSS": 7.7,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-6965",
-        "advisoryId": "RHS-2025:20936",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:20936",
-        "componentName": "sqlite-libs",
-        "componentVersion": "3.34.1-8.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-52099",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 5.3,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-52099",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "sqlite-libs",
-        "componentVersion": "3.34.1-8.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2024-0232",
-        "cveSeverity": "LOW",
-        "cveCVSS": 4.7,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2024-0232",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "sqlite-libs",
-        "componentVersion": "3.34.1-8.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-5278",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 4.4,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-5278",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "coreutils-single",
-        "componentVersion": "8.32-39.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-10966",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 5.9,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-10966",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "curl-minimal",
-        "componentVersion": "7.76.1-31.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-9086",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 5.3,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-9086",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "curl-minimal",
-        "componentVersion": "7.76.1-31.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2024-11053",
-        "cveSeverity": "LOW",
-        "cveCVSS": 5.9,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2024-11053",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "curl-minimal",
-        "componentVersion": "7.76.1-31.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2024-7264",
-        "cveSeverity": "LOW",
-        "cveCVSS": 5.3,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2024-7264",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "curl-minimal",
-        "componentVersion": "7.76.1-31.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2024-9681",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.9,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2024-9681",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "curl-minimal",
-        "componentVersion": "7.76.1-31.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-13601",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 7.7,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-13601",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "glib2",
-        "componentVersion": "2.68.4-16.el9_6.2",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2023-32636",
-        "cveSeverity": "LOW",
-        "cveCVSS": 6.2,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2023-32636",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "glib2",
-        "componentVersion": "2.68.4-16.el9_6.2",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-3360",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.7,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-3360",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "glib2",
-        "componentVersion": "2.68.4-16.el9_6.2",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-32988",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 6.5,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-32988",
-        "advisoryId": "RHSA-2025:16116",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:16116",
-        "componentName": "gnutls",
-        "componentVersion": "3.8.3-6.el9",
-        "componentFixedVersion": "0:3.8.3-6.el9_6.2"
-      },
-      {
-        "cveId": "CVE-2025-32990",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 6.5,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-32990",
-        "advisoryId": "RHSA-2025:16116",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:16116",
-        "componentName": "gnutls",
-        "componentVersion": "3.8.3-6.el9",
-        "componentFixedVersion": "0:3.8.3-6.el9_6.2"
-      },
-      {
-        "cveId": "CVE-2025-6395",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 6.5,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-6395",
-        "advisoryId": "RHSA-2025:16116",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:16116",
-        "componentName": "gnutls",
-        "componentVersion": "3.8.3-6.el9",
-        "componentFixedVersion": "0:3.8.3-6.el9_6.2"
-      },
-      {
-        "cveId": "CVE-2025-32989",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 5.3,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-32989",
-        "advisoryId": "RHSA-2025:16116",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:16116",
-        "componentName": "gnutls",
-        "componentVersion": "3.8.3-6.el9",
-        "componentFixedVersion": "0:3.8.3-6.el9_6.2"
-      },
-      {
-        "cveId": "CVE-2025-14104",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 6.1,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-14104",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libblkid",
-        "componentVersion": "2.37.4-21.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-10966",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 5.9,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-10966",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libcurl-minimal",
-        "componentVersion": "7.76.1-31.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-9086",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 5.3,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-9086",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libcurl-minimal",
-        "componentVersion": "7.76.1-31.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2024-11053",
-        "cveSeverity": "LOW",
-        "cveCVSS": 5.9,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2024-11053",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libcurl-minimal",
-        "componentVersion": "7.76.1-31.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2024-7264",
-        "cveSeverity": "LOW",
-        "cveCVSS": 5.3,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2024-7264",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libcurl-minimal",
-        "componentVersion": "7.76.1-31.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2024-9681",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.9,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2024-9681",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libcurl-minimal",
-        "componentVersion": "7.76.1-31.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-14104",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 6.1,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-14104",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libmount",
-        "componentVersion": "2.37.4-21.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-14104",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 6.1,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-14104",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libsmartcols",
-        "componentVersion": "2.37.4-21.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-14104",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 6.1,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-14104",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libuuid",
-        "componentVersion": "2.37.4-21.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-32415",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 7.5,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-32415",
-        "advisoryId": "RHSA-2025:13428",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:13428",
-        "componentName": "libxml2",
-        "componentVersion": "2.9.13-11.el9_6",
-        "componentFixedVersion": "0:2.9.13-12.el9_6"
-      },
-      {
-        "cveId": "CVE-2025-9714",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 6.2,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-9714",
-        "advisoryId": "RHSA-2025:22376",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:22376",
-        "componentName": "libxml2",
-        "componentVersion": "2.9.13-11.el9_6",
-        "componentFixedVersion": "0:2.9.13-14.el9_7"
-      },
-      {
-        "cveId": "CVE-2025-32414",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 5.6,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-32414",
-        "advisoryId": "RHSA-2025:13428",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:13428",
-        "componentName": "libxml2",
-        "componentVersion": "2.9.13-11.el9_6",
-        "componentFixedVersion": "0:2.9.13-12.el9_6"
-      },
-      {
-        "cveId": "CVE-2023-45322",
-        "cveSeverity": "LOW",
-        "cveCVSS": 5.9,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2023-45322",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libxml2",
-        "componentVersion": "2.9.13-11.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2024-34459",
-        "cveSeverity": "LOW",
-        "cveCVSS": 5.5,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2024-34459",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libxml2",
-        "componentVersion": "2.9.13-11.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-27113",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.1,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-27113",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libxml2",
-        "componentVersion": "2.9.13-11.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-6170",
-        "cveSeverity": "LOW",
-        "cveCVSS": 2.5,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-6170",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libxml2",
-        "componentVersion": "2.9.13-11.el9_6",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-9230",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 5.6,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-9230",
-        "advisoryId": "RHSA-2025:21255",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:21255",
-        "componentName": "openssl-libs",
-        "componentVersion": "1:3.2.2-6.el9_5.1",
-        "componentFixedVersion": "1:3.5.1-4.el9_7"
-      },
-      {
-        "cveId": "CVE-2024-41996",
-        "cveSeverity": "LOW",
-        "cveCVSS": 5.9,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2024-41996",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "openssl-libs",
-        "componentVersion": "1:3.2.2-6.el9_5.1",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2024-13176",
-        "cveSeverity": "LOW",
-        "cveCVSS": 4.7,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2024-13176",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "openssl-libs",
-        "componentVersion": "1:3.2.2-6.el9_5.1",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-9232",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.1,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-9232",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "openssl-libs",
-        "componentVersion": "1:3.2.2-6.el9_5.1",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-4598",
-        "cveSeverity": "MODERATE",
-        "cveCVSS": 4.7,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-4598",
-        "advisoryId": "RHSA-2025:22660",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:22660",
-        "componentName": "systemd-libs",
-        "componentVersion": "252-51.el9_6.1",
-        "componentFixedVersion": "0:252-55.el9_7.7"
-      },
-      {
-        "cveId": "CVE-2023-4156",
-        "cveSeverity": "LOW",
-        "cveCVSS": 6.1,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2023-4156",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "gawk",
-        "componentVersion": "5.1.0-6.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2022-3219",
-        "cveSeverity": "LOW",
-        "cveCVSS": 6.2,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2022-3219",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "gnupg2",
-        "componentVersion": "2.3.3-4.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-30258",
-        "cveSeverity": "LOW",
-        "cveCVSS": 2.7,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-30258",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "gnupg2",
-        "componentVersion": "2.3.3-4.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2022-27943",
-        "cveSeverity": "LOW",
-        "cveCVSS": 5.5,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2022-27943",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libgcc",
-        "componentVersion": "11.5.0-5.el9_5",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2022-27943",
-        "cveSeverity": "LOW",
-        "cveCVSS": 5.5,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2022-27943",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "libstdc++",
-        "componentVersion": "11.5.0-5.el9_5",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2025-62813",
-        "cveSeverity": "LOW",
-        "cveCVSS": 0,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2025-62813",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "lz4-libs",
-        "componentVersion": "1.9.3-5.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2023-50495",
-        "cveSeverity": "LOW",
-        "cveCVSS": 6.5,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2023-50495",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "ncurses-base",
-        "componentVersion": "6.2-10.20210508.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2022-29458",
-        "cveSeverity": "LOW",
-        "cveCVSS": 6.1,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2022-29458",
-        "advisoryId": "RHSA-2025:12876",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:12876",
-        "componentName": "ncurses-base",
-        "componentVersion": "6.2-10.20210508.el9",
-        "componentFixedVersion": "0:6.2-10.20210508.el9_6.2"
-      },
-      {
-        "cveId": "CVE-2023-50495",
-        "cveSeverity": "LOW",
-        "cveCVSS": 6.5,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2023-50495",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "ncurses-libs",
-        "componentVersion": "6.2-10.20210508.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2022-29458",
-        "cveSeverity": "LOW",
-        "cveCVSS": 6.1,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2022-29458",
-        "advisoryId": "RHSA-2025:12876",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:12876",
-        "componentName": "ncurses-libs",
-        "componentVersion": "6.2-10.20210508.el9",
-        "componentFixedVersion": "0:6.2-10.20210508.el9_6.2"
-      },
-      {
-        "cveId": "CVE-2022-41409",
-        "cveSeverity": "LOW",
-        "cveCVSS": 5.3,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2022-41409",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "pcre2",
-        "componentVersion": "10.40-6.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2022-41409",
-        "cveSeverity": "LOW",
-        "cveCVSS": 5.3,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2022-41409",
-        "advisoryId": "",
-        "advisoryInfo": "",
-        "componentName": "pcre2-syntax",
-        "componentVersion": "10.40-6.el9",
-        "componentFixedVersion": ""
-      },
-      {
-        "cveId": "CVE-2024-56433",
-        "cveSeverity": "LOW",
-        "cveCVSS": 3.6,
-        "cveInfo": "https://access.redhat.com/security/cve/CVE-2024-56433",
-        "advisoryId": "RHSA-2025:20559",
-        "advisoryInfo": "https://access.redhat.com/errata/RHSA-2025:20559",
-        "componentName": "shadow-utils",
-        "componentVersion": "2:4.9-12.el9",
-        "componentFixedVersion": "2:4.9-15.el9"
-      }
-    ]
-  }
-}
+    {
+      "cve": "CVE-2023-30571",
+      "advisory": [],
+      "summary": "An unpatched critical vulnerability in libarchive.",
+      "links": [
+        "https://access.redhat.com/security/cve/CVE-2023-30571"
+      ],
+      "fixedBy": "",
+      "severity": "CRITICAL_VULNERABILITY_SEVERITY",
+      "components": [
+        {
+          "component": "libarchive",
+          "version": "3.5.3-5.el9_6",
+          "source": "var/lib/rpm"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2025-5914",
+      "advisory": [
+        {
+          "name": "RHSA-2025:14130",
+          "link": "https://access.redhat.com/errata/RHSA-2025:14130"
+        }
+      ],
+      "summary": "A high severity vulnerability in libarchive.",
+      "links": [
+        "https://access.redhat.com/security/cve/CVE-2025-5914"
+      ],
+      "fixedBy": "0:3.5.3-6.el9_6",
+      "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+      "components": [
+        {
+          "component": "libarchive",
+          "version": "3.5.3-5.el9_6",
+          "source": "var/lib/rpm"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2024-12345",
+      "advisory": [],
+      "summary": "An unpatched high severity vulnerability affecting multiple components.",
+      "links": [
+        "https://access.redhat.com/security/cve/CVE-2024-12345"
+      ],
+      "fixedBy": "",
+      "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+      "components": [
+        {
+          "component": "openssl-libs",
+          "version": "3.0.7-27.el9",
+          "source": "var/lib/rpm"
+        },
+        {
+          "component": "openssl",
+          "version": "3.0.7-27.el9",
+          "source": "var/lib/rpm"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2024-33602",
+      "advisory": [
+        {
+          "name": "RHSA-2024:5363",
+          "link": "https://access.redhat.com/errata/RHSA-2024:5363"
+        }
+      ],
+      "summary": "A medium severity vulnerability in glibc.",
+      "links": [
+        "https://access.redhat.com/security/cve/CVE-2024-33602"
+      ],
+      "fixedBy": "0:2.34-100.el9_4.4",
+      "severity": "MODERATE_VULNERABILITY_SEVERITY",
+      "components": [
+        {
+          "component": "glibc",
+          "version": "2.34-100.el9_4.2",
+          "source": "var/lib/rpm"
+        },
+        {
+          "component": "glibc-common",
+          "version": "2.34-100.el9_4.2",
+          "source": "var/lib/rpm"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2021-20197",
+      "advisory": [],
+      "summary": "An unpatched medium severity vulnerability in binutils.",
+      "links": [
+        "https://access.redhat.com/security/cve/CVE-2021-20197"
+      ],
+      "fixedBy": "",
+      "severity": "MODERATE_VULNERABILITY_SEVERITY",
+      "components": [
+        {
+          "component": "binutils",
+          "version": "2.35.2-63.el9",
+          "source": "var/lib/rpm"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2022-29458",
+      "advisory": [
+        {
+          "name": "RHSA-2025:12876",
+          "link": "https://access.redhat.com/errata/RHSA-2025:12876"
+        }
+      ],
+      "summary": "A low severity vulnerability in ncurses.",
+      "links": [
+        "https://access.redhat.com/security/cve/CVE-2022-29458"
+      ],
+      "fixedBy": "0:6.2-10.20210508.el9_6.2",
+      "severity": "LOW_VULNERABILITY_SEVERITY",
+      "components": [
+        {
+          "component": "ncurses-base",
+          "version": "6.2-10.20210508.el9",
+          "source": "var/lib/rpm"
+        },
+        {
+          "component": "ncurses-libs",
+          "version": "6.2-10.20210508.el9",
+          "source": "var/lib/rpm"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2021-3572",
+      "advisory": [],
+      "summary": "An unpatched low severity vulnerability in pip.",
+      "links": [
+        "https://access.redhat.com/security/cve/CVE-2021-3572"
+      ],
+      "fixedBy": "",
+      "severity": "LOW_VULNERABILITY_SEVERITY",
+      "components": [
+        {
+          "component": "python3-pip-wheel",
+          "version": "21.3.1-1.el9",
+          "source": "var/lib/rpm"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2025-5918",
+      "advisory": [],
+      "summary": "A low severity vulnerability with no links.",
+      "links": [],
+      "fixedBy": "",
+      "severity": "LOW_VULNERABILITY_SEVERITY",
+      "components": [
+        {
+          "component": "libarchive1",
+          "version": "3.5.3-5.el9_6",
+          "source": "var/lib/rpm"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2025-5917",
+      "advisory": [],
+      "summary": "A low severity vulnerability with non-redhat link.",
+      "links": [
+        "https://nvd.nist.gov/vuln/detail/CVE-2025-5917"
+      ],
+      "fixedBy": "",
+      "severity": "LOW_VULNERABILITY_SEVERITY",
+      "components": [
+        {
+          "component": "libarchive2",
+          "version": "3.5.3-5.el9_6",
+          "source": "var/lib/rpm"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Adapt the vulnerability-check policies to consume the new CVE-oriented format produced by the ACS parser instead of the old per-component flat format.
Update severity constants, input traversal, and test data.
