### PR TITLE
docs(STONEINTG-1613): add AGENTS.md and CONTRIBUTING.md guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+## AGENTS.md
+
+This is the Konflux-test repository for building the image of the same name. The main purpose of this image is to store resources used in Konflux CI Tekton tasks and pipelines such as tools, `conftest` policies and bash utility functions.
+
+## Technology Stack
+
+- **Language**: Rego, bash
+- **Pipeline engine**: Tekton PipelineRuns
+- **Testing**: Tekton integration pipelines and GitHub actions
+- **Build**: Dockerfile, Tekton build pipelines
+
+## Repository Structure
+
+```
+policies/              # OPA/conftest policies written in Rego that are used in Konflux Tekton tasks for validating formatted outputs
+test/                  # Bash utility functions which are used in Tekton steps along with associated test files
+parsers/               # JQ parsers for transforming JSON outputs
+unittests/             # OPA Rego unit tests for policies contained in the policies/ directory
+unittests_bash/        # Bats-powered unit tests for bash utility functions contained in the test/ directory
+.tekton/               # Tekton build PipelineRuns which create Tekton bundle images
+integration-tests/     # Tekton integration test PipelineRuns for validating the image's functionality
+rpms.*                 # Contain packages that are built hermetically with their corresponding location
+hack/                  # Various scripts that are used during the CI runs
+```
+
+## Architecture
+
+### Conftest Policies
+The most important part of this repository is the collection of OPA Rego policies in the `policies/` directory which are meant to be executed by the `conftest` utility. These policies are meant to validate structured outputs from different checks which are executed as part of the Tekton tasks mainly located in the [konflux-test-tasks](https://github.com/konflux-ci/konflux-test-tasks/),  [konflux-operator-tasks](https://github.com/konflux-ci/konflux-operator-tasks) and [konflux-sast-tasks](https://github.com/konflux-ci/konflux-sast-tasks) repositories.
+
+### Bash utility functions
+The Bash utility functions in the `test/` directory are meant to be used in the Tekton task steps in order to support the Konflux CI Tekton task logic. These functions are meant to reduce the size and complexity of the scripts embedded within the Task steps, while being more directly testable by the Bats unit tests in the `unittests_bash/` directory.
+
+### Image-hosted utilities
+The `konflux-test` image also contains additional utilities (binaries, scripts, etc.) which are required by the Konflux CI Tekton tasks. See the `Dockerfile` for more details on them.
+
+## Development Guidelines
+
+- See `CONTRIBUTING.md` for overall guidelines for making contributions to this repository.
+- **Git**: conventional commits with Jira ticket as scope — `type(issue-id): description` (e.g. `feat(STONEINTG-1519): create PR group snapshots from ComponentGroups`)
+    - The `main` branch is read only, never push there directly, a new feature branch must be created instead
+    - Pull requests are used to propose changes to the `main` branch
+- Don't change whitespaces or newlines in the existing unrelated code and never add whitespaces or tabs to empty lines
+- Don't remove unrelated code and don't change files when/where modifications are not needed
+- Don't add trailing newlines at the end of file, last newline character is at the end of code
+- Make sure that the OPA Rego policies are covered by unit tests in the `unittests` directory
+- Make sure that the bash functions are covered by unit tests in the `unittests_bash` directory
+- Make sure that the Dockerfile is well-formatted and does not include unnecessary layers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing
+
+- [How to Report Issues](#how-to-report-issues)
+- [How to Submit Pull Requests](#how-to-submit-pull-requests)
+    - [Development Workflow](#development-workflow)
+    - [Pull Request Guidelines](#pull-request-guidelines)
+    - [Security basics](#security-basics)
+- [Review Process](#review-process)
+
+
+Contributions of all kinds are welcome. In particular pull requests are appreciated. The authors and maintainers will endeavor to help walk you through any issues in the pull request discussion, so please feel free to open a pull request even if you are new to such things.
+
+> [!NOTE]
+> This repository is used in [Konflux](https://konflux-ci.dev).
+> Therefore, everybody should follow its [Code of Conduct](https://github.com/konflux-ci/community/blob/main/CODE_OF_CONDUCT.md).
+
+## How to Report Issues
+
+- We encourage early communication for all types of contributions.
+- Before filing an issue, make sure to check if it is not reported already.
+- If the contribution is non-trivial (straightforward bugfixes, typos, etc.), please open an issue to discuss your plans and get guidance from maintainers.
+
+## How to Submit Pull Requests
+
+### Development Workflow
+
+1. **Fork and Clone**: Fork this repository and clone your fork
+2. **Create Feature Branch**: Create a new topic branch based on `main`
+3. **Make Changes**: Implement your changes. Consult [README.md](README.md) for the structure and development details.
+4. **Commit Changes**: See [commit guidelines](#pull-request-guidelines)
+
+### Pull Request Guidelines
+
+**Commit Requirements:**
+
+- Follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages
+- Write clear, descriptive commit titles. Should fit under 72 characters
+- Write meaningful commit descriptions with each line having less than 72 characters
+- Split your contribution into several commits if applicable, each should represent a logical chunk
+- Add line `Assisted-by: <name-of-ai-tool>` if you used an AI tool for your contribution
+- Sign-off your commits in order to certify that you adhere to [Developer Certificate of Origin](https://developercertificate.org)
+
+**Pull Request Content:**
+
+- **Title**: Clear, descriptive title. Should fit under 72 characters.
+- **Description**: Explain the overall changes and their purpose, this should be a cover letter for your commits.
+- **Testing**: Describe how the changes were tested
+- **Links**: Reference related issues or upstream stories.
+
+**Remember:**
+
+- Konflux is a community project and proper descriptions cannot be replaced by referencing a publicly inaccessible link to Jira or any other private resource.
+- Reviewers, other contributors and future generations might not have the same context as you have at the moment of PR submission.
+
+### Security basics
+
+- Never commit secrets or keys to the repository
+- Never expose or log sensitive information
+
+## Review Process
+
+**Requirements for Approval:**
+
+- All CI checks pass
+- Code review approval from maintainers
+
+**Review Criteria:**
+
+- The contribution follows established patterns and conventions
+- Changes are tested and documented
+- Security best practices are followed
+
+For any questions or help with contributing, please open an issue or reach out to the maintainers.


### PR DESCRIPTION
* Add the AGENTS.md with the basic context information for the repository including project structure, architecture and development guides
* Add the CONTRIBUTING.md with the standardized guidance for contributors to Konflux controller repositories

Signed-off-by: dirgim <kpavic@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED