### PR TITLE
Add function to get previous OCP version

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -463,6 +463,44 @@ get_ocp_version_from_fbc_fragment() {
   fi
 }
 
+# This function will be used by tekton tasks in build-definitions
+# Returns the previous OCP catalog version for a given OCP version.
+# Handles the cross-major version boundary (e.g., v5.0 -> v4.22).
+# Usage: get_prev_ocp_version OCP_VERSION
+#   OCP_VERSION: target OCP version (e.g., v5.0 or 5.0)
+get_prev_ocp_version() {
+  if [ -z "${1:-}" ]; then
+    echo "get_prev_ocp_version: Missing positional parameter \$1 (OCP_VERSION)" >&2
+    exit 2
+  fi
+
+  local OCP_VERSION="${1#v}"
+  local major minor
+  major=$(echo "$OCP_VERSION" | awk -F'.' '{print $1}')
+  minor=$(echo "$OCP_VERSION" | awk -F'.' '{print $2}')
+
+  if [ -z "$major" ] || [ -z "$minor" ] || ! [[ "$major" =~ ^[0-9]+$ ]] || ! [[ "$minor" =~ ^[0-9]+$ ]]; then
+    echo "get_prev_ocp_version: Invalid OCP version format '$1' (expected vX.Y or X.Y)" >&2
+    exit 2
+  fi
+
+  if [[ "${minor}" -eq 0 ]]; then
+    # Cross-major boundary: decrementing minor yields an invalid version (e.g. v5.-1).
+    # Map the previous major to its last known minor release.
+    # To support a future major boundary, add an entry: [prev_major]=last_minor
+    declare -A last_minor_of_prev_major=([4]=22)
+    local prev_major=$(( major - 1 ))
+    local prev_minor=${last_minor_of_prev_major[${prev_major}]:-}
+    if [[ -z "${prev_minor}" ]]; then
+      echo "get_prev_ocp_version: No cross-major version mapping for '${1}' (previous major: ${prev_major})" >&2
+      exit 1
+    fi
+    echo "v${prev_major}.${prev_minor}"
+  else
+    echo "v${major}.$(( minor - 1 ))"
+  fi
+}
+
 # Given output of `opm render` command and package name, this function returns
 # all unique bundles for the given package in the catalog
 extract_unique_bundles_from_catalog() {

--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -2252,3 +2252,63 @@ Dangerous globals: 0"
     [ "$(echo "$output" | jq -r '.summary.infected_files')" = "0" ]
     [ "$(echo "$output" | jq -r '.summary.dangerous_globals')" = "0" ]
 }
+
+@test "Get prev OCP version: missing argument" {
+    run get_prev_ocp_version
+    EXPECTED_RESPONSE="get_prev_ocp_version: Missing positional parameter \$1 (OCP_VERSION)"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 2 ]]
+}
+
+@test "Get prev OCP version: invalid format (no dot)" {
+    run get_prev_ocp_version v5
+    EXPECTED_RESPONSE="get_prev_ocp_version: Invalid OCP version format 'v5' (expected vX.Y or X.Y)"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 2 ]]
+}
+
+@test "Get prev OCP version: v5.0 cross-major boundary returns v4.22" {
+    run get_prev_ocp_version v5.0
+    EXPECTED_RESPONSE="v4.22"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get prev OCP version: 5.0 without v-prefix returns v4.22" {
+    run get_prev_ocp_version 5.0
+    EXPECTED_RESPONSE="v4.22"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get prev OCP version: v5.1 returns v5.0" {
+    run get_prev_ocp_version v5.1
+    EXPECTED_RESPONSE="v5.0"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get prev OCP version: v4.23 returns v4.22" {
+    run get_prev_ocp_version v4.23
+    EXPECTED_RESPONSE="v4.22"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get prev OCP version: v4.1 returns v4.0" {
+    run get_prev_ocp_version v4.1
+    EXPECTED_RESPONSE="v4.0"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 0 ]]
+}
+
+@test "Get prev OCP version: v6.0 unknown mapping returns error" {
+    run get_prev_ocp_version v6.0
+    EXPECTED_RESPONSE="get_prev_ocp_version: No cross-major version mapping for 'v6.0' (previous major: 5)"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
+}
+
+@test "Get prev OCP version: v4.0 unknown cross-major mapping returns error" {
+    run get_prev_ocp_version v4.0
+    EXPECTED_RESPONSE="get_prev_ocp_version: No cross-major version mapping for 'v4.0' (previous major: 3)"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
+}
+
+@test "Get prev OCP version: non-numeric minor returns invalid format error" {
+    run get_prev_ocp_version v5.abc
+    EXPECTED_RESPONSE="get_prev_ocp_version: Invalid OCP version format 'v5.abc' (expected vX.Y or X.Y)"
+    [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 2 ]]
+}


### PR DESCRIPTION
Refers to KONFLUX-13978

Introduces get_prev_ocp_version() to compute the previous OCP catalog
version from a given target version. The function handles the cross-major
boundary case (e.g. v5.0 → v4.22) via a lookup map, replacing duplicated
inline arithmetic in fbc-fips-* Tekton tasks in build-definitions.

Previously each task independently computed:
  prev_minor_version=$(("${minor_ocp_version}" - 1))
which yields v5.-1 (an invalid catalog tag) when minor is 0.

The function is designed to be extensible: adding [5]=N to
last_minor_of_prev_major is all that is needed when OCP v6.0 ships.