### PR TITLE
feat(STONEINTG-1641): add AI skills for konflux-test repo

### DIFF
--- a/.claude/skills/adding-tools-to-image
+++ b/.claude/skills/adding-tools-to-image
@@ -1,0 +1,1 @@
+../../skills/adding-tools-to-image

--- a/.claude/skills/ci-cd-quirks
+++ b/.claude/skills/ci-cd-quirks
@@ -1,0 +1,1 @@
+../../skills/ci-cd-quirks

--- a/.claude/skills/pr-definition-of-done
+++ b/.claude/skills/pr-definition-of-done
@@ -1,0 +1,1 @@
+../../skills/pr-definition-of-done

--- a/.claude/skills/running-tests-locally
+++ b/.claude/skills/running-tests-locally
@@ -1,0 +1,1 @@
+../../skills/running-tests-locally

--- a/.claude/skills/writing-bash-functions
+++ b/.claude/skills/writing-bash-functions
@@ -1,0 +1,1 @@
+../../skills/writing-bash-functions

--- a/.claude/skills/writing-rego-policies
+++ b/.claude/skills/writing-rego-policies
@@ -1,0 +1,1 @@
+../../skills/writing-rego-policies

--- a/skills/SKILLS.md
+++ b/skills/SKILLS.md
@@ -1,0 +1,33 @@
+# Konflux-test AI Skills
+
+Repository-specific AI skills for the konflux-test container image. These skills are tool-agnostic and can be used with any AI agent (Claude Code, Codex, Goose, etc.) via symlinks to the agent's skill directory.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| [writing-rego-policies](writing-rego-policies/SKILL.md) | How to write OPA/conftest Rego policies: package naming, rule prefixes, violation objects, conftest namespaces, and unit tests |
+| [writing-bash-functions](writing-bash-functions/SKILL.md) | How to add bash utility functions to test/utils.sh, naming conventions, BATS tests, mock patterns, and TEST_OUTPUT format |
+| [running-tests-locally](running-tests-locally/SKILL.md) | How to run OPA unit tests, BATS tests, shellcheck, hadolint, conftest integration tests, and coverage reporting |
+| [pr-definition-of-done](pr-definition-of-done/SKILL.md) | Pre-push checklist: conventional commits, Rego policy tests at 100% coverage, BATS tests, code quality checks |
+| [ci-cd-quirks](ci-cd-quirks/SKILL.md) | Non-obvious CI/CD behavior: hermetic builds, Tekton pipelines, GitHub Actions checks, integration test structure |
+| [adding-tools-to-image](adding-tools-to-image/SKILL.md) | How to add new tools/binaries to the container image: artifacts.lock.yaml, rpms.in.yaml, multi-arch support, hermetic builds |
+
+## Setup for Claude Code
+
+Skills are symlinked from `.claude/skills/` for automatic discovery:
+
+```
+.claude/skills/writing-rego-policies -> ../../skills/writing-rego-policies
+.claude/skills/writing-bash-functions -> ../../skills/writing-bash-functions
+...
+```
+
+## Setup for Other Agents
+
+Create symlinks from your agent's skill directory to `skills/`:
+
+```bash
+# Example for Codex
+ln -s ../../skills/writing-rego-policies .agents/skills/writing-rego-policies
+```

--- a/skills/adding-tools-to-image/SKILL.md
+++ b/skills/adding-tools-to-image/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: adding-tools-to-image
+description: Use when adding new tools, binaries, or packages to the konflux-test container image. Covers artifacts.lock.yaml (generic binaries), rpms.in.yaml (system packages), multi-architecture support, and hermetic build constraints.
+---
+
+# Adding Tools to the Image
+
+## Overview
+
+The konflux-test container image contains 40+ tools and binaries for Konflux CI Tekton tasks. Adding a new tool requires updates to three files due to hermetic build constraints and multi-architecture support.
+
+## When to Use
+
+- Adding a new binary/utility to the image
+- Adding a system package via dnf
+- Updating tool versions
+- Supporting a new architecture
+
+## Quick Reference
+
+| Dependency type | Declaration file | Lockfile | Dockerfile |
+|--------|----------|----------|-----------|
+| System packages (RPM) | `rpms.in.yaml` | `rpms.lock.yaml` | `dnf install ...` |
+| Binaries/artifacts | `artifacts.lock.yaml` | N/A | `COPY ${PATH_TO_ART}/...` |
+
+## Adding an RPM Package
+
+1. **Edit `rpms.in.yaml`** — add package name to the `packages:` list
+2. **Regenerate lockfile** — cachi2 generates `rpms.lock.yaml` with pinned versions and checksums
+3. **Edit `Dockerfile`** — add `dnf install` command in the build stage
+4. **Verify in CI** — CI validates the package installs correctly in hermetic build
+
+**Example:**
+```yaml
+# rpms.in.yaml
+packages:
+  - jq
+  - python3
+  - new-package-name  # Add here
+```
+
+## Adding a Binary/Artifact
+
+1. **Get download URL and checksum** (sha256) for both architectures
+2. **Edit `artifacts.lock.yaml`** — add entry with URL, checksum, filename for amd64 AND arm64
+3. **Edit `Dockerfile`** — add conditional COPY with `$TARGETARCH` logic
+4. **Verify in CI** — CI builds for both architectures
+
+**Example:**
+```yaml
+# artifacts.lock.yaml
+- download_url: https://github.com/owner/repo/releases/download/v1.2.0/tool-linux-amd64.tar.gz
+  checksum: sha256:abc123def456...
+  filename: tool-amd64.tar.gz
+- download_url: https://github.com/owner/repo/releases/download/v1.2.0/tool-linux-arm64.tar.gz
+  checksum: sha256:def456abc123...
+  filename: tool-arm64.tar.gz
+```
+
+**Dockerfile pattern:**
+```dockerfile
+FROM ubi9/ubi:9.7 AS final
+
+ARG TARGETARCH
+
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      cp ${PATH_TO_ART}/tool-amd64.tar.gz /tmp/ && \
+      tar xzf /tmp/tool-amd64.tar.gz -C /usr/local/bin; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+      cp ${PATH_TO_ART}/tool-arm64.tar.gz /tmp/ && \
+      tar xzf /tmp/tool-arm64.tar.gz -C /usr/local/bin; \
+    fi
+```
+
+The `PATH_TO_ART` variable is set by hermetic build system (=/cachi2/output/deps/generic).
+
+## Hermetic Build Constraints
+
+**Critical:** All dependencies must be declared BEFORE build starts — no network access during build.
+
+- **RPM packages:** declared in `rpms.in.yaml`, locked in `rpms.lock.yaml`
+- **Generic artifacts:** declared in `artifacts.lock.yaml` with checksums
+- **Cachi2:** prefetches all dependencies offline before build
+- **Multi-arch:** every binary must have both amd64 and arm64 variants with separate checksums
+
+If a tool is missing from either lockfile, the hermetic build will fail: `ERROR: dependency not found`.
+
+## Multi-Architecture Support
+
+The build system uses `TARGETARCH` (set by buildkit) to select architecture-specific binaries:
+
+```dockerfile
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then copy-amd64; \
+    elif [ "$TARGETARCH" = "arm64" ]; then copy-arm64; \
+    fi
+```
+
+**Every multi-arch binary in `artifacts.lock.yaml` needs BOTH amd64 and arm64 entries with separate checksums.**
+
+## Multiple Versions
+
+Tools like opm are intentionally installed at multiple versions for backwards compatibility with different OCP versions (v1.26.4 through v1.57.0). Each version is a separate artifact entry.
+
+## Validating the Tool
+
+After adding a tool, `test/selftest.sh` should validate:
+
+1. Binary is present and executable
+2. Binary returns expected version/help output
+3. Binary works correctly in integration tests
+
+Add a validation check to `test/selftest.sh`:
+
+```bash
+if ! command -v new-tool &> /dev/null; then
+    echo "ERROR: new-tool not found in image"
+    exit 1
+fi
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Missing from artifacts.lock.yaml | Add entry with download_url, checksum, filename (both arches) |
+| Only amd64 variant, missing arm64 | Every binary needs both variants with separate checksums |
+| Wrong checksum format | Use `sha256:` prefix and full hash (not abbreviated) |
+| Dockerfile COPY wrong path | Use `${PATH_TO_ART}/filename` (=/cachi2/output/deps/generic) |
+| Dockerfile forgot $TARGETARCH condition | Both amd64 and arm64 builds will fail with "file not found" |
+| Tool not validated in selftest.sh | Add `command -v tool` check and version validation |

--- a/skills/ci-cd-quirks/SKILL.md
+++ b/skills/ci-cd-quirks/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: ci-cd-quirks
+description: Use when CI checks fail unexpectedly, when preparing code for CI, or when encountering non-obvious build and pipeline behavior. Covers hermetic builds, Tekton pipelines, multi-arch, GitHub Actions checks, and integration test structure.
+---
+
+# CI/CD Quirks and Gotchas
+
+## Overview
+
+CI runs on both GitHub Actions (linting, unit tests) and Konflux Tekton pipelines (image builds, integration tests). Several non-obvious requirements trip up developers.
+
+## When to Use
+
+- CI failed and the error is unclear
+- Preparing a change that touches dependencies, policies, or the Dockerfile
+- Understanding build pipeline behavior
+- Debugging integration test failures
+
+## GitHub Actions Checks
+
+**File:** `.github/workflows/pr-checks.yaml`
+
+| Check | What it does | Strict enforcement |
+|-------|-------------|------------|
+| yamllint | Lints all YAML files | Yes, fails PR |
+| hadolint | Lints Dockerfile (ignores DL3003,DL3013,DL3041,DL4006) | Yes, fails PR |
+| opa_policies_unittest | OPA tests + coverage check (**100% coverage required** — fails if any line uncovered) | Yes, fails PR |
+| bash_unittests | BATS tests for bash functions | Yes, fails PR |
+| shellcheck | Bash linting on `test/` (ignores conftest.sh, selftest.sh) | Yes, fails PR |
+| gitlint | Validates commit message format | PR-only, enforces lowercase after colon (custom rule UC1) |
+
+**Critical detail:** OPA coverage enforcement uses jq to assert:
+```bash
+jq -j -r 'if .coverage < 100 then "ERROR: Code coverage threshold not met: got \(.coverage) instead of 100.00\n" | halt_error(1) else "" end'
+```
+
+## Tekton Build Pipeline
+
+**PR Pipeline:** `.tekton/konflux-test-pull-request.yaml`
+- Hermetic build (network-isolated, dependencies prefetched via Cachi2)
+- Multi-arch: builds for amd64 and arm64
+- Image tag: `on-pr-{{revision}}`
+- Expires after 5 days, max 3 kept
+- Cancel-in-progress: only one PR pipeline per PR at a time
+
+**Push Pipeline:** `.tekton/konflux-test-push.yaml`
+- Regular build + security scans
+- Image tag: `{{revision}}`
+- Triggered on merge to main
+
+## Integration Test Pipeline
+
+**File:** `integration-tests/konflux_test_validation.yaml`
+
+Runs INSIDE the built image after build succeeds:
+
+1. **test-metadata** — Extract image URL, git revision
+2. **shellcheck** — Lints shell scripts (excludes conftest.sh, selftest.sh)
+3. **hadolint** — Lints Dockerfile
+4. **self-test** — Runs `/selftest.sh` (smoke tests: binaries present, conftest works)
+5. **opa-policy-unittests** — Runs `opa test` on ./policies (100% coverage enforced)
+6. **bats-unit-tests** — Runs `bats unittests_bash` (expects cosign in `/usr/local/bin`)
+
+Output format: Uses Tekton result functions (`make_result_json`, `parse_test_output`, `handle_error`).
+
+## Hermetic Build Constraints
+
+All dependencies must be pre-declared — no network access during build:
+
+**RPM packages:** `rpms.in.yaml` → `rpms.lock.yaml` (generated lockfile)
+```yaml
+packages:
+  - jq
+  - python3
+  - skopeo
+```
+
+**Generic artifacts:** `artifacts.lock.yaml` (binaries, tarballs)
+```yaml
+- download_url: https://github.com/operator-framework/operator-registry/releases/download/v1.57.0/linux-amd64-opm.tar.gz
+  checksum: sha256:abc123...
+  filename: opm-v1.57.0.tar.gz
+```
+
+**Critical:** Hermetic build requires **both amd64 and arm64 variants** for each multi-arch binary.
+
+Dockerfile uses:
+```bash
+if [ "$TARGETARCH" = "amd64" ]; then
+    cp ${PATH_TO_ART}/opm-amd64 /usr/local/bin/opm
+elif [ "$TARGETARCH" = "arm64" ]; then
+    cp ${PATH_TO_ART}/opm-arm64 /usr/local/bin/opm
+fi
+```
+
+## Common Mistakes
+
+| Problem | Root cause | Fix |
+|---------|-----------|-----|
+| OPA coverage exactly 99.x% | CI enforces **100%** strictly | Add test for uncovered policy line |
+| `shellcheck` passes locally, fails CI | Different flags (`-s bash` in CI) | Run locally with: `shellcheck -s bash test/utils.sh` |
+| Binary "not found" after build | Missing from `artifacts.lock.yaml` | Add both amd64 and arm64 variants with checksums |
+| Integration tests fail but unit tests pass | Tests run inside the image | Check Dockerfile COPY paths and selftest.sh validation |
+| Hadolint fails on new instruction | Rule not in ignore list | Check `.github/workflows/pr-checks.yaml` for `ignore:` field |
+| New RPM package fails hermetic build | Not declared in rpms.in.yaml | Add package name and regenerate rpms.lock.yaml |

--- a/skills/pr-definition-of-done/SKILL.md
+++ b/skills/pr-definition-of-done/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: pr-definition-of-done
+description: Use when preparing a pull request for review or before pushing. Checklist of commit conventions, Rego policy tests at 100% coverage, BATS tests, code quality checks, and CI check requirements.
+---
+
+# PR Definition of Done
+
+## Overview
+
+Every PR must pass CI checks, follow commit conventions, include tests with 100% coverage for policies, and avoid unnecessary whitespace changes.
+
+## When to Use
+
+- Before pushing a PR for review
+- When CI checks fail unexpectedly
+- When reviewing someone else's PR
+
+## Pre-Push Checklist
+
+### Commits
+- [ ] Conventional format: `type(JIRA-ID): description` (e.g., `feat(STONEINTG-1641): add AI skills`)
+- [ ] Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`
+- [ ] **Description starts lowercase** (gitlint custom rule UC1 — this is strict)
+- [ ] Title < 72 chars, body lines < 72 chars
+- [ ] Signed off (DCO): `git commit -s`
+- [ ] AI-assisted work: add `Assisted-by: <tool-name>` trailer
+
+### Testing
+- [ ] New/modified Rego policies: add/update unit tests in `unittests/test_{scanner}/`
+- [ ] New/modified bash functions: add/update BATS tests in `unittests_bash/`
+- [ ] **OPA policy coverage at 100%** — CI enforces this strictly
+- [ ] `opa test policies unittests unittests/test_data -c` passes
+- [ ] `bats unittests_bash` passes
+
+### Code Quality
+- [ ] `shellcheck -s bash test/utils.sh` passes (excludes conftest.sh, selftest.sh)
+- [ ] `hadolint Dockerfile` passes (with standard ignores: DL3003,DL3013,DL3041,DL4006)
+- [ ] No whitespace or newline changes in unrelated code
+- [ ] No whitespace or tabs on empty lines
+- [ ] Files must end with exactly one newline character (no extra trailing newlines)
+- [ ] No removal of unrelated code
+
+### Security
+- [ ] Never commit secrets, keys, or credentials
+
+## What CI Checks
+
+| Check | Workflow | What fails it |
+|-------|----------|---------------|
+| OPA unit tests | `pr-checks.yaml` / `opa_policies_unittest` | Any test failure or coverage < 100% |
+| BATS tests | `pr-checks.yaml` / `bash_unittests` | Any BATS test failure |
+| Shellcheck | `pr-checks.yaml` / `shellcheck` | Violations in `test/` (excludes conftest.sh, selftest.sh) |
+| Hadolint | `pr-checks.yaml` / `Dockerfile-linter` | Dockerfile lint violations |
+| YAML lint | `pr-checks.yaml` / `YAML-Linter` | yamllint violations |
+| Gitlint | `pr-checks.yaml` / `gitlint` | Non-conventional format, title > 72 chars, uppercase after colon |
+| Tekton build | `.tekton/` | Image build failure, security scans |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Commit description starts uppercase | Must start lowercase — gitlint custom rule UC1 enforces |
+| OPA coverage drops below 100% | Add tests for every new policy rule line |
+| Added whitespace to unrelated lines | Review diff carefully, revert formatting-only changes |
+| Forgot to add test data fixture | New policies need test data in `unittests/test_data/` |
+| `shellcheck` passes locally but fails in CI | Run with `-s bash` flag: `shellcheck -s bash test/utils.sh` |

--- a/skills/running-tests-locally/SKILL.md
+++ b/skills/running-tests-locally/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: running-tests-locally
+description: Use when running OPA policy unit tests, BATS bash tests, shellcheck, hadolint, or conftest integration tests locally. Covers test commands, coverage requirements, test data, and prerequisites.
+---
+
+# Running Tests Locally
+
+## Overview
+
+Tests are split into OPA Rego unit tests (policies/), BATS bash tests (utils.sh), conftest integration tests (policy/data integration), and linters (shellcheck, hadolint, yamllint).
+
+## When to Use
+
+- Running tests before pushing
+- Debugging test failures
+- Checking code coverage
+- Understanding test infrastructure
+
+## Quick Reference
+
+| Command | What it does |
+|---------|-------------|
+| `opa test policies unittests unittests/test_data -c` | OPA policy unit tests with coverage |
+| `bats unittests_bash` | All BATS bash unit tests |
+| `shellcheck -s bash test/utils.sh` | Lint bash functions |
+| `hadolint Dockerfile` | Lint Dockerfile (ignore DL3003,DL3013,DL3041,DL4006) |
+| `yamllint .` | Lint all YAML files |
+
+## OPA Policy Tests
+
+**Prerequisites:** install `opa` binary (v0.56.0 used in CI)
+
+**Command:** `opa test policies unittests unittests/test_data -c`
+
+**Coverage requirement:** **100%** — every line of policy code must be covered by at least one test. CI enforces this with jq assertion: `coverage >= 100.00`.
+
+**Coverage reporting:**
+```bash
+opa test --coverage --format json policies unittests unittests/test_data \
+  | opa eval --data hack/simplecov.rego data.simplecov.from_opa > coverage.json
+```
+
+This generates codecov-compatible JSON for CI upload.
+
+## BATS Bash Tests
+
+**Prerequisites:** bats v1.8.2, jq, cosign
+
+**Run all tests:**
+```bash
+bats unittests_bash
+```
+
+**Run single test file:**
+```bash
+bats unittests_bash/test_utils.bats
+```
+
+**Run tests matching pattern:**
+```bash
+bats unittests_bash/test_utils.bats -f "test name pattern"
+```
+
+Tests source `test/utils.sh` directly and mock external tools (skopeo, opm, cosign).
+
+## Conftest Integration Tests
+
+**File:** `test/conftest.sh` (BATS format, separate from unit tests)
+
+**Setup:**
+```bash
+export POLICY_PATH=policies
+```
+
+**Run:**
+```bash
+bats test/conftest.sh
+```
+
+Tests the actual conftest CLI invocation against real policies, not just Rego logic. Uses three namespaces:
+- `--namespace required_checks` — blocking policies
+- `--namespace optional_checks` — advisory policies
+- `--namespace fbc_checks` — FBC-specific policies
+
+## Image Smoke Test
+
+**File:** `test/selftest.sh`
+
+Validates the built Docker image has:
+- Required binaries: yq, skopeo, snyk, ec, cosign, clamscan
+- conftest CLI working with all three namespaces
+- parse_test_output bash function correct
+- Clair/scanning API integration functional
+
+Run inside the container after building the image (automated in integration test pipeline).
+
+## Linters
+
+**Shellcheck:**
+```bash
+shellcheck -s bash test/utils.sh
+```
+Ignores conftest.sh and selftest.sh (they have special formats).
+
+**Hadolint:**
+```bash
+hadolint Dockerfile
+```
+Ignores rules: DL3003, DL3013, DL3041, DL4006
+
+**Yamllint:**
+```bash
+yamllint .
+```
+Uses `.yamllint` config, ignores `/vendor`.
+
+## Common Mistakes
+
+| Problem | Fix |
+|---------|-----|
+| OPA coverage < 100% | Add test for every policy rule and helper function |
+| BATS test fails "command not found" | Install prerequisites: jq, cosign, bats 1.8.2 |
+| Shellcheck SC2086 | Quote variables: `"${var}"` not `$var` |
+| OPA test "undefined ref" | Check import path matches test_data filename (no extension) |
+| conftest.sh fails | Set `export POLICY_PATH=policies` before running |

--- a/skills/writing-bash-functions/SKILL.md
+++ b/skills/writing-bash-functions/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: writing-bash-functions
+description: Use when adding or modifying bash utility functions in test/utils.sh. Covers naming conventions, function structure, BATS tests, mock patterns for external tools, TEST_OUTPUT format, and shellcheck compliance.
+---
+
+# Writing Bash Functions
+
+## Overview
+
+Bash utility functions in `test/utils.sh` support Tekton task steps by handling image parsing, scanning output parsing, OPM operations, Pyxis API calls, and Tekton result formatting. File contains 100+ functions across 2000+ lines.
+
+## When to Use
+
+- Adding new functions to test/utils.sh
+- Writing BATS tests in unittests_bash/
+- Understanding mock patterns for skopeo/opm
+- Debugging shellcheck failures
+
+## Quick Reference
+
+| Item | Location/Convention |
+|------|-------------------|
+| Main functions file | `test/utils.sh` |
+| BATS test files | `unittests_bash/test_utils.bats`, `unittests_bash/test_cosign.bats` |
+| Test data fixtures | `unittests_bash/data/*.json` |
+| Integration tests | `test/conftest.sh` (separate BATS file) |
+
+## Function Naming Conventions
+
+| Prefix | Purpose | Example |
+|--------|---------|---------|
+| `get_` | Retrieve/extract a value | `get_image_labels()`, `get_base_image()` |
+| `extract_` | Parse complex data | `extract_unique_bundles_from_catalog()` |
+| `parse_` | Transform format | `parse_image_url()`, `parse_test_output()` |
+| `handle_` | Error handling | `handle_error()`, `handle_pyxis_response_pages()` |
+| `make_` | Construct output | `make_result_json()` |
+| `validate_` | Check conditions | `validate_ocp_version()` |
+| `replace_` | Substitute values | `replace_image_pullspec()` |
+
+## Function Structure Pattern
+
+```bash
+function_name() {
+    # Parameter validation
+    if [ -z "$1" ]; then
+        echo "ERROR: parameter required" >&2
+        exit 2
+    fi
+    
+    local result="$1"
+    # Use local for all variables
+    
+    # Return via echo -n (no trailing newline for JSON)
+    echo -n "$result"
+}
+```
+
+**Exit codes:** 0=success, 1=error, 2=parameter error, 3=format error
+
+## Tekton Result Functions
+
+Three critical output functions consumed by Tekton:
+
+| Function | Purpose | Output format |
+|----------|---------|----------------|
+| `make_result_json` | Format Tekton task result | JSON with name, value, type |
+| `parse_test_output` | Convert conftest/sarif JSON to TEST_OUTPUT | Structured JSON with result, timestamp, note, namespace |
+| `handle_error` | Trap and report errors | Tekton error result with structured message |
+
+See `test/utils.sh` for full implementations.
+
+## Writing BATS Tests
+
+**File:** `unittests_bash/test_{name}.bats`
+
+```bash
+#!/usr/bin/env bats
+
+setup() {
+    source test/utils.sh
+    
+    # Mock external tools as bash functions
+    skopeo() {
+        if [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "docker://registry/image@digest" ]]; then
+            echo '{"Name": "image", "Architecture": "amd64"}'
+        fi
+    }
+    
+    export -f skopeo
+}
+
+@test "get_image_labels returns labels" {
+    run get_image_labels "registry/image@digest"
+    [ "$status" -eq 0 ]
+    [ "$output" != "" ]
+}
+```
+
+**Patterns:**
+- `@test "description" { ... }` — BATS test format
+- `run function_name args` — Execute and capture result
+- `[ "$status" -eq 0 ]` — Assert exit code
+- `test_json_eq expected_json output_json` — Compare JSON (ignores timestamps)
+- `export -f mock_function` — Export mock function to subshells
+
+## Mock Pattern: skopeo
+
+Skopeo is mocked in `setup()` as a bash function with if-elif branches:
+
+```bash
+skopeo() {
+    if [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://image@digest" ]]; then
+        echo '{"schemaVersion": 2, ...}'
+    elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "docker://image@digest" ]]; then
+        echo '{"Name": "image", ...}'
+    fi
+}
+```
+
+Add new elif branches for each new image reference you test.
+
+## Test Data Fixtures
+
+JSON/YAML files in `unittests_bash/data/` used as mock API responses:
+
+- `conftest_failures.json` — conftest output with violations
+- `conftest_successes.json` — conftest output with no violations
+- `sarif_failures.json` — SARIF format vulnerability data
+- Test data sourced via `@test` context or as function arguments
+
+## Shellcheck Compliance
+
+Run before pushing:
+```bash
+shellcheck -s bash test/utils.sh
+```
+
+**Common violations:**
+- SC2086: Quote variables: `"${var}"` not `$var`
+- SC2181: Check exit code of specific command, not $?
+- SC2119: Function called without args but expects them
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Missing `local` keyword | All function-local variables must use `local` |
+| Using `echo` instead of `echo -n` | Trailing newline breaks JSON piping to jq |
+| Not mocking external tools | setup() must override skopeo, opm, cosign as functions |
+| Wrong test data path | File `unittests_bash/data/conftest_failures.json` sourced in test |
+| Shellcheck violation | Run `shellcheck -s bash test/utils.sh` before pushing |
+| Not exporting mock function | Use `export -f function_name` so subshells see the mock |

--- a/skills/writing-rego-policies/SKILL.md
+++ b/skills/writing-rego-policies/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: writing-rego-policies
+description: Use when writing, modifying, or reviewing OPA/conftest Rego policies. Covers package naming, rule prefixes (violation_ and warn_), conftest namespaces, violation object structures, imports, and unit test patterns.
+---
+
+# Writing Rego Policies
+
+## Overview
+
+Policies in `policies/{scanner}/` validate structured outputs from Tekton security scanners using OPA and conftest. Each policy is a Rego package that generates violations or warnings based on input data from scanners like Clair, ClamAV, PickleScan, Roxctl, and RHTPA.
+
+## When to Use
+
+- Writing a new Rego policy for a new scanner or check
+- Modifying existing policy logic
+- Understanding conftest namespace organization
+- Writing unit tests for policies
+
+## Quick Reference
+
+| Item | Convention |
+|------|-----------|
+| Policy location | `policies/{scanner}/{check-name}.rego` |
+| Test location | `unittests/test_{scanner}/{check-name}_test.rego` |
+| Test data | `unittests/test_data/{scanner}.json` or `.yaml` |
+| Package names | `required_checks`, `optional_checks`, or `fbc_checks` |
+| Rule prefixes | `violation_*` (failures), `warn_*` (warnings) |
+| Conftest invocation | `conftest test ... --namespace required_checks` |
+
+## Package Names and Conftest Namespaces
+
+Policies use three package names, selected via `--namespace` flag:
+
+| Package | Namespace flag | Purpose | Example |
+|---------|---|---------|---------|
+| `required_checks` | `--namespace required_checks` | Blocking policies, must pass | clair, roxctl, picklescan, image/required-labels |
+| `optional_checks` | `--namespace optional_checks` | Advisory warnings | image/inherited-labels, image/optional-labels |
+| `fbc_checks` | `--namespace fbc_checks` | FBC (File-Based Catalog) specific | image/fbc-labels |
+
+A single `.rego` file contains exactly ONE package name.
+
+## Rule Naming Prefixes
+
+| Prefix | Conftest result | Use when |
+|--------|-----------------|----------|
+| `violation_` | Failure (blocks image) | Check must pass for image acceptance (most policies) |
+| `warn_` | Warning (informational) | Check is advisory and doesn't block |
+| `deny_` | Failure | Alternative prefix (not used in current policies) |
+
+## Violation/Warning Object Structures
+
+**Rules must return a LIST** (list comprehension `[{...} | ...]`), never a single object.
+
+Structures vary by policy type:
+
+### Vulnerability Scanning (clair, rhtpa, roxctl warn rules)
+```rego
+[{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}}]
+```
+
+### Label/Image Checks (image/*)
+```rego
+[{"msg": msg, "details": {"name": name, "description": description, "url": url}}]
+```
+(No `vulnerabilities_number` field)
+
+### Virus Scanning (clamav, picklescan)
+```rego
+[{"msg": msg, "details": {"filename": filename, "virname": virname, "description": description}}]
+```
+(ClamAV); or `{"filename": filename, "finding": finding}` (PickleScan)
+
+### Roxctl Discrepancies
+```rego
+[{"msg": msg, "discrepancies_number": disc_num, "details": {"name": name, "description": description, "url": url}}]
+```
+
+## Helper Function Patterns
+
+Vulnerability policies typically define:
+```rego
+get_patched_vulnerabilities(input_data, severity) := vulnerabilities if { ... }
+get_unpatched_vulnerabilities(input_data, severity) := vulnerabilities if { ... }
+count_vulnerabilities(vulnerabilities) := cnt if { ... }
+generate_description(vulnerabilities) := dsc if { ... }
+```
+
+Then use these in rule definitions. See `policies/clair/vulnerabilities-check.rego` for full pattern.
+
+## Imports
+
+**NOT all policies use imports.** Add imports only when needed:
+
+| Import | Use when |
+|--------|----------|
+| `import future.keywords.if` | Using `if` keyword in rule definitions |
+| `import future.keywords.in` | Using `in` operator for membership checks |
+| `import data as base_image` | Accessing other data packages (rare) |
+
+Label/image policies typically have **no imports**.
+
+## Default Values
+
+Use `default` to safely return empty arrays when data is absent:
+```rego
+default warn_critical_vulnerabilities := []
+```
+
+Only used in `policies/rhtpa/vulnerabilities-check.rego`.
+
+## Writing Unit Tests
+
+Same package as policy, in `unittests/test_{scanner}/{check-name}_test.rego`:
+
+```rego
+package required_checks
+
+import data.clair as clair
+import future.keywords.if
+
+test_warn_critical_vulnerabilities if {
+    result := warn_critical_vulnerabilities with input as clair
+    result[_].details.name == "clair_critical_vulnerabilities"
+    result[_].vulnerabilities_number == 1
+}
+```
+
+**Patterns:**
+- Import test data as `import data.{fixture_name} as {alias}`
+- Test function name: `test_{rule_name}`
+- Inject data: `with input as fixture_alias`
+- Assert on `.details.name`, `.vulnerabilities_number`, `.msg`
+- Test clean input: `rule_name == [] with input as clean_data`
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Wrong package name | Must match conftest `--namespace` flag exactly |
+| Returning single object instead of list | Rules must be list comprehensions: `[{...} \| ...]` |
+| Wrong detail object keys | Use correct keys for policy type (see structures above) |
+| Test data import wrong | File `unittests/test_data/clair.json` → `import data.clair as clair` |
+| Missing test for empty input | Add negative test: `rule == [] with input as empty_data` |
+| Using `if` without importing | Add `import future.keywords.if` |


### PR DESCRIPTION
Add 6 repository-specific AI skills following the integration-service pattern:
- writing-rego-policies: OPA/conftest policy patterns, package naming, rule types, 5 violation structures, unit tests
- writing-bash-functions: utils.sh conventions, BATS tests, mock patterns, TEST_OUTPUT format
- running-tests-locally: OPA tests (100% coverage requirement), BATS, shellcheck, hadolint, selftest.sh
- pr-definition-of-done: pre-push checklist with conventional commits, 100% coverage, CI check mapping
- ci-cd-quirks: GitHub Actions checks, Tekton pipelines, hermetic builds, multi-arch, integration test structure
- adding-tools-to-image: RPM packages, artifacts.lock.yaml, multi-arch binaries, hermetic build constraints

All skills are symlinked from .claude/skills/ for Claude Code discovery. Content verified against actual codebase patterns, CI workflows, and policy examples.

Assisted-By: Claude Code Opus 4.6 + Haiku 