### PR TITLE
chore: enable regex-style-search in gitlint

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,4 +1,5 @@
 [general]
+regex-style-search=true
 contrib=contrib-title-conventional-commits,CC1
 extra-path=.github/gitlint
 ignore=T5
@@ -14,4 +15,4 @@ line-length=72
 [contrib-title-conventional-commits]
 
 [ignore-by-author-name]
-regex=(.*)(dependabot|red-hat-konflux)(.*)
+regex=dependabot|red-hat-konflux


### PR DESCRIPTION
See https://github.com/konflux-ci/konflux-test/actions/runs/26533750819/job/78156987796?pr=824 for example of warning that this fixes