### PR TITLE
fix: bump CHECK_PAYLOAD_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:9.7-1778675823 as check-payload-
 
 #check-payload
 WORKDIR /opt/app-root/src
-ARG CHECK_PAYLOAD_VERSION=0.3.14
+ARG CHECK_PAYLOAD_VERSION=0.3.15
 
 RUN tar -xzf /cachi2/output/deps/generic/check-payload-${CHECK_PAYLOAD_VERSION}.tar.gz &&  cd check-payload-${CHECK_PAYLOAD_VERSION} && \
     CGO_ENABLED=0 go build -ldflags="-X main.Commit=${CHECK_PAYLOAD_VERSION}" -o /opt/app-root/src/check-payload-binary && \

--- a/artifacts.lock.yaml
+++ b/artifacts.lock.yaml
@@ -2,9 +2,9 @@
 metadata: 
   version: "1.0"
 artifacts:
-  - download_url: "https://github.com/openshift/check-payload/archive/refs/tags/0.3.14.tar.gz"
-    checksum: "sha256:928c4e67f29db8aaef3b56b213e4da40b8fb51d7c4c6bb7b7e689099c00d73fc"
-    filename: "check-payload-0.3.14.tar.gz"
+  - download_url: "https://github.com/openshift/check-payload/archive/refs/tags/0.3.15.tar.gz"
+    checksum: "sha256:83e4f8c203f4cf8cf1056b5e3d0877579f740974eea090c948a04e9548e9a74f"
+    filename: "check-payload-0.3.15.tar.gz"
   - download_url: "https://github.com/CycloneDX/sbom-utility/releases/download/v0.12.0/sbom-utility-v0.12.0-linux-amd64.tar.gz"
     checksum: "sha256:762072a297f499691d59eeb3405aa873b6e71ea8f18d7db496511e584b0f5bb1"
     filename: "sbom-utility.tar.gz"


### PR DESCRIPTION
a new check-payload version was created with a bug fix that was causing the tool to fail for s390x images. This change bumps our check-payload version to the latest one