### PR TITLE
feat: introduce pre-commit hooks for local checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-added-large-files
+
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint
+        args:
+          - --ignore=DL3003
+          - --ignore=DL3013
+          - --ignore=DL3041
+          - --ignore=DL4006
+
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: v0.19.1
+    hooks:
+      - id: gitlint
+        stages: [commit-msg]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 - [How to Report Issues](#how-to-report-issues)
 - [How to Submit Pull Requests](#how-to-submit-pull-requests)
     - [Development Workflow](#development-workflow)
+    - [Local Development Setup](#local-development-setup)
     - [Pull Request Guidelines](#pull-request-guidelines)
     - [Security basics](#security-basics)
 - [Review Process](#review-process)
@@ -28,6 +29,42 @@ Contributions of all kinds are welcome. In particular pull requests are apprecia
 2. **Create Feature Branch**: Create a new topic branch based on `main`
 3. **Make Changes**: Implement your changes. Consult [README.md](README.md) for the structure and development details.
 4. **Commit Changes**: See [commit guidelines](#pull-request-guidelines)
+
+### Local Development Setup
+
+This repository uses [pre-commit](https://pre-commit.com/) to run checks locally before each commit.
+
+pipx:
+```sh
+pipx install pre-commit
+pre-commit install
+```
+
+uvx:
+```sh
+uvx pre-commit install
+uvx pre-commit
+```
+
+**What the hooks check:**
+
+| Hook | What it catches |
+|------|-----------------|
+| trailing-whitespace | Trailing whitespace in any file |
+| end-of-file-fixer | Missing or extra final newline |
+| check-yaml | YAML syntax errors |
+| check-added-large-files | Accidentally committed large binaries |
+| yamllint | YAML style violations (uses `.yamllint` config) |
+| shellcheck | Bash issues in `test/utils.sh` |
+| hadolint | Dockerfile lint violations |
+| gitlint | Non-conventional commit messages, title > 72 chars, uppercase description |
+
+**Running hooks manually:**
+
+```bash
+pre-commit run --all-files    # run all hooks on all files
+pre-commit run yamllint       # run a specific hook
+```
 
 ### Pull Request Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,16 +34,19 @@ Contributions of all kinds are welcome. In particular pull requests are apprecia
 
 This repository uses [pre-commit](https://pre-commit.com/) to run checks locally before each commit.
 
-pipx:
+**One-time setup (pipx):**
+
 ```sh
 pipx install pre-commit
 pre-commit install
+pre-commit install --hook-type commit-msg
 ```
 
-uvx:
+**Or with uvx:**
+
 ```sh
 uvx pre-commit install
-uvx pre-commit
+uvx pre-commit install --hook-type commit-msg
 ```
 
 **What the hooks check:**
@@ -54,8 +57,6 @@ uvx pre-commit
 | end-of-file-fixer | Missing or extra final newline |
 | check-yaml | YAML syntax errors |
 | check-added-large-files | Accidentally committed large binaries |
-| yamllint | YAML style violations (uses `.yamllint` config) |
-| shellcheck | Bash issues in `test/utils.sh` |
 | hadolint | Dockerfile lint violations |
 | gitlint | Non-conventional commit messages, title > 72 chars, uppercase description |
 
@@ -63,7 +64,8 @@ uvx pre-commit
 
 ```bash
 pre-commit run --all-files    # run all hooks on all files
-pre-commit run yamllint       # run a specific hook
+pre-commit run hadolint       # run a specific hook
+pre-commit autoupdate         # update hooks to latest versions
 ```
 
 ### Pull Request Guidelines


### PR DESCRIPTION
Add .pre-commit-config.yaml with hooks that mirror the CI checks:
- trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files
- yamllint (reuses existing .yamllint config)
- shellcheck (scoped to test/utils.sh, matching CI exclusions)
- hadolint (with the same DL3003/DL3013/DL3041/DL4006 ignores as CI)
- gitlint (commit-msg hook for conventional commit validation)

Update CONTRIBUTING.md with a "Local Development Setup" section documenting the one-time setup, what each hook checks, how to run hooks manually, and how to bypass in emergencies.

Assisted-by: Cursor
gitlint-ignore: B1