### PR TITLE
Stoneintg 1686

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -37,7 +37,36 @@ jobs:
       - uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: Dockerfile
-          ignore: DL3003,DL3013,DL3041,DL4006  # DL4006 seems broken
+
+  regal-lint:
+    name: Regal Rego linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Run Regal
+        uses: StyraInc/regal-action@v1
+        with:
+          args: lint policies/ unittests/ hack/
+
+  opa-fmt-check:
+    name: Check OPA formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Install OPA
+        run: |
+          sudo curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/v0.56.0/opa_linux_amd64_static
+          sudo chmod 755 /usr/bin/opa
+      - name: Check OPA formatting
+        run: |
+          diff=$(opa fmt --diff policies/ unittests/ hack/)
+          if [ -n "$diff" ]; then
+            echo "::error::OPA formatting check failed. Run 'opa fmt -w policies/ unittests/ hack/' to fix."
+            echo "$diff"
+            exit 1
+          fi
 
   opa_policies_unittest:
     name: opa_policies_unittest
@@ -103,8 +132,6 @@ jobs:
       - uses: actions/checkout@v7
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
-        env:
-          SHELLCHECK_OPTS: -s bash
         with:
           scandir: './test'
           ignore_paths: './test/conftest.sh ./test/selftest.sh'  # for now

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,10 @@
+---
+ignored:
+  - DL3003
+  - DL3013
+  - DL3041
+  - DL4006
+trustedRegistries:
+  - registry.access.redhat.com
+  - registry.redhat.io
+  - quay.io

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -1,0 +1,37 @@
+rules:
+  idiomatic:
+    directory-package-mismatch:
+      level: ignore
+    equals-pattern-matching:
+      level: ignore
+    no-defined-entrypoint:
+      level: ignore
+  imports:
+    confusing-alias:
+      level: ignore
+    implicit-future-keywords:
+      level: ignore
+    pointless-import:
+      level: ignore
+    redundant-data-import:
+      level: ignore
+    unresolved-import:
+      level: ignore
+    unresolved-reference:
+      level: ignore
+  style:
+    avoid-get-and-list-prefix:
+      level: ignore
+    line-length:
+      level: ignore
+    opa-fmt:
+      level: ignore
+    prefer-some-in-iteration:
+      level: ignore
+    unconditional-assignment:
+      level: ignore
+    use-assignment-operator:
+      level: error
+  testing:
+    test-outside-test-package:
+      level: ignore

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+shell=bash

--- a/hack/simplecov.rego
+++ b/hack/simplecov.rego
@@ -4,18 +4,21 @@ package simplecov
 import future.keywords
 
 from_opa := {"coverage": coverage}
-default  file = ""
-default  obj = {"lines": []}
-default  cm := ""
-default  ncm = ""
 
+default file := ""
 
-coverage[file] = obj if {
+default obj := {"lines": []}
+
+default cm := ""
+
+default ncm := ""
+
+coverage[file] := obj if {
 	some file, report in input.files
 	obj := {"lines": lines(report)}
 }
 
-covered_map(report) = cm if {
+covered_map(report) := cm if {
 	covered := object.get(report, "covered", [])
 	cm := {line: 1 |
 		some item in covered
@@ -23,7 +26,7 @@ covered_map(report) = cm if {
 	}
 }
 
-not_covered_map(report) = ncm if {
+not_covered_map(report) := ncm if {
 	not_covered := object.get(report, "not_covered", [])
 	ncm := {line: 0 |
 		some item in not_covered
@@ -31,7 +34,7 @@ not_covered_map(report) = ncm if {
 	}
 }
 
-lines(report) = lines if {
+lines(report) := lines if {
 	cm := covered_map(report)
 	ncm := not_covered_map(report)
 	keys := sort([line | some line, _ in object.union(cm, ncm)])
@@ -43,15 +46,15 @@ lines(report) = lines if {
 	]
 }
 
-to_value(cm, _, line) = 1 if {
+to_value(cm, _, line) := 1 if {
 	cm[line]
 }
 
-to_value(_, ncm, line) = 0 if {
+to_value(_, ncm, line) := 0 if {
 	ncm[line]
 }
 
-to_value(cm, ncm, line) = null if {
+to_value(cm, ncm, line) := null if {
 	not cm[line]
 	not ncm[line]
 }

--- a/policies/clair/vulnerabilities-check.rego
+++ b/policies/clair/vulnerabilities-check.rego
@@ -4,145 +4,145 @@ import future.keywords.if
 
 # function to get mapping {rpm: set of vulnerabilities names}; duplicated vulnerabilities are removed
 get_patched_vulnerabilities(input_data, severity) := vulnerabilities if {
-  vulnerabilities := [{"name": rpm.Name, "version": rpm.Version, "vulnerabilities": vuln} |
-    rpm := input_data.data[_].Features[_]
-    vuln := {v.Name | v:=rpm.Vulnerabilities[_]; v.Severity == severity; v.FixedBy != ""; contains(v.Link,"RHSA")}
-    count(vuln) > 0
-  ]
+	vulnerabilities := [{"name": rpm.Name, "version": rpm.Version, "vulnerabilities": vuln} |
+		rpm := input_data.data[_].Features[_]
+		vuln := {v.Name | v := rpm.Vulnerabilities[_]; v.Severity == severity; v.FixedBy != ""; contains(v.Link, "RHSA")}
+		count(vuln) > 0
+	]
 }
 
 # function to get mapping {rpm: set of vulnerabilities names}; duplicated vulnerabilities are removed
 get_unpatched_vulnerabilities(input_data, severity) := vulnerabilities if {
-  vulnerabilities := [{"name": rpm.Name, "version": rpm.Version, "vulnerabilities": vuln} |
-    rpm := input_data.data[_].Features[_]
-    vuln := {v.Name | v:=rpm.Vulnerabilities[_]; v.Severity == severity; v.FixedBy == ""; not contains(v.Link,"RHSA")}
-    count(vuln) > 0
-  ]
+	vulnerabilities := [{"name": rpm.Name, "version": rpm.Version, "vulnerabilities": vuln} |
+		rpm := input_data.data[_].Features[_]
+		vuln := {v.Name | v := rpm.Vulnerabilities[_]; v.Severity == severity; v.FixedBy == ""; not contains(v.Link, "RHSA")}
+		count(vuln) > 0
+	]
 }
-
 
 # function returns count of all vulnerabilities
 count_vulnerabilities(vulnerabilities) := cnt if {
-  cnt := sum([count(v.vulnerabilities) | v:=vulnerabilities[_]])
+	cnt := sum([count(v.vulnerabilities) | v := vulnerabilities[_]])
 }
 
 # function generates description with RPMs and their vulnerabilities
 generate_description(vulnerabilities) := dsc if {
-  dsc := sprintf("Vulnerabilities found: %s", [concat(", ",
-                   [sprintf("%s-%s (%s)", [v.name, v.version, concat(", ", v.vulnerabilities)]) | v := vulnerabilities[_]]
-                 )])
+	dsc := sprintf("Vulnerabilities found: %s", [concat(
+		", ",
+		[sprintf("%s-%s (%s)", [v.name, v.version, concat(", ", v.vulnerabilities)]) | v := vulnerabilities[_]],
+	)])
 }
 
-warn_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
-  rpms_with_critical_vulnerabilities := get_patched_vulnerabilities(input, "Critical")
-  not count(rpms_with_critical_vulnerabilities) == 0
+warn_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
+	rpms_with_critical_vulnerabilities := get_patched_vulnerabilities(input, "Critical")
+	not count(rpms_with_critical_vulnerabilities) == 0
 
-  name := "clair_critical_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_critical_vulnerabilities)
-  msg := "Found packages with critical vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description := generate_description(rpms_with_critical_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_critical_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_critical_vulnerabilities)
+	msg := "Found packages with critical vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	description := generate_description(rpms_with_critical_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
-warn_unpatched_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
-  rpms_with_unpatched_critical_vulnerabilities := get_unpatched_vulnerabilities(input, "Critical")
-  not count(rpms_with_unpatched_critical_vulnerabilities) == 0
+warn_unpatched_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
+	rpms_with_unpatched_critical_vulnerabilities := get_unpatched_vulnerabilities(input, "Critical")
+	not count(rpms_with_unpatched_critical_vulnerabilities) == 0
 
-  name := "clair_unpatched_critical_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_unpatched_critical_vulnerabilities)
-  msg := "Found packages with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := generate_description(rpms_with_unpatched_critical_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unpatched_critical_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_unpatched_critical_vulnerabilities)
+	msg := "Found packages with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := generate_description(rpms_with_unpatched_critical_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
-warn_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
-  rpms_with_high_vulnerabilities := get_patched_vulnerabilities(input, "High")
-  not count(rpms_with_high_vulnerabilities) == 0
+warn_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
+	rpms_with_high_vulnerabilities := get_patched_vulnerabilities(input, "High")
+	not count(rpms_with_high_vulnerabilities) == 0
 
-  name := "clair_high_vulnerabilities"
-  vulns_num = count_vulnerabilities(rpms_with_high_vulnerabilities)
-  msg := "Found packages with high vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description := generate_description(rpms_with_high_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_high_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_high_vulnerabilities)
+	msg := "Found packages with high vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	description := generate_description(rpms_with_high_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
-warn_unpatched_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
-  rpms_with_unpatched_high_vulnerabilities := get_unpatched_vulnerabilities(input, "High")
-  not count(rpms_with_unpatched_high_vulnerabilities) == 0
+warn_unpatched_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
+	rpms_with_unpatched_high_vulnerabilities := get_unpatched_vulnerabilities(input, "High")
+	not count(rpms_with_unpatched_high_vulnerabilities) == 0
 
-  name := "clair_unpatched_high_vulnerabilities"
-  vulns_num = count_vulnerabilities(rpms_with_unpatched_high_vulnerabilities)
-  msg := "Found packages with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := generate_description(rpms_with_unpatched_high_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unpatched_high_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_unpatched_high_vulnerabilities)
+	msg := "Found packages with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := generate_description(rpms_with_unpatched_high_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
-warn_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
-  rpms_with_medium_vulnerabilities := get_patched_vulnerabilities(input, "Medium")
-  not count(rpms_with_medium_vulnerabilities) == 0
+warn_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
+	rpms_with_medium_vulnerabilities := get_patched_vulnerabilities(input, "Medium")
+	not count(rpms_with_medium_vulnerabilities) == 0
 
-  name := "clair_medium_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_medium_vulnerabilities)
-  msg := "Found packages with medium vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description := generate_description(rpms_with_medium_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_medium_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_medium_vulnerabilities)
+	msg := "Found packages with medium vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	description := generate_description(rpms_with_medium_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
-warn_unpatched_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
-  rpms_with_unpatched_medium_vulnerabilities := get_unpatched_vulnerabilities(input, "Medium")
-  not count(rpms_with_unpatched_medium_vulnerabilities) == 0
+warn_unpatched_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
+	rpms_with_unpatched_medium_vulnerabilities := get_unpatched_vulnerabilities(input, "Medium")
+	not count(rpms_with_unpatched_medium_vulnerabilities) == 0
 
-  name := "clair_unpatched_medium_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_unpatched_medium_vulnerabilities)
-  msg := "Found packages with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := generate_description(rpms_with_unpatched_medium_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unpatched_medium_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_unpatched_medium_vulnerabilities)
+	msg := "Found packages with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := generate_description(rpms_with_unpatched_medium_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
-warn_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
-  rpms_with_low_vulnerabilities := get_patched_vulnerabilities(input, "Low")
-  rpms_with_negligible_vulnerabilities := get_patched_vulnerabilities(input, "Negligible")
-  rpms_with_low_neg_vulnerabilities = array.concat(rpms_with_low_vulnerabilities, rpms_with_negligible_vulnerabilities)
-  not count(rpms_with_low_neg_vulnerabilities) == 0
+warn_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
+	rpms_with_low_vulnerabilities := get_patched_vulnerabilities(input, "Low")
+	rpms_with_negligible_vulnerabilities := get_patched_vulnerabilities(input, "Negligible")
+	rpms_with_low_neg_vulnerabilities := array.concat(rpms_with_low_vulnerabilities, rpms_with_negligible_vulnerabilities)
+	not count(rpms_with_low_neg_vulnerabilities) == 0
 
-  name := "clair_low_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_low_neg_vulnerabilities)
-  msg := "Found packages with low/negligible vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description := generate_description(rpms_with_low_neg_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_low_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_low_neg_vulnerabilities)
+	msg := "Found packages with low/negligible vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	description := generate_description(rpms_with_low_neg_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
-warn_unpatched_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
-  rpms_with_unpatched_low_vulnerabilities := get_unpatched_vulnerabilities(input, "Low")
-  rpms_with_unpatched_negligible_vulnerabilities := get_unpatched_vulnerabilities(input, "Negligible")
-  rpms_with_unpatched_low_neg_vulnerabilities = array.concat(rpms_with_unpatched_low_vulnerabilities, rpms_with_unpatched_negligible_vulnerabilities)
-  not count(rpms_with_unpatched_low_neg_vulnerabilities) == 0
+warn_unpatched_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
+	rpms_with_unpatched_low_vulnerabilities := get_unpatched_vulnerabilities(input, "Low")
+	rpms_with_unpatched_negligible_vulnerabilities := get_unpatched_vulnerabilities(input, "Negligible")
+	rpms_with_unpatched_low_neg_vulnerabilities := array.concat(rpms_with_unpatched_low_vulnerabilities, rpms_with_unpatched_negligible_vulnerabilities)
+	not count(rpms_with_unpatched_low_neg_vulnerabilities) == 0
 
-  name := "clair_unpatched_low_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_unpatched_low_neg_vulnerabilities)
-  msg := "Found packages with unpatched low/negligible vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := generate_description(rpms_with_unpatched_low_neg_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unpatched_low_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_unpatched_low_neg_vulnerabilities)
+	msg := "Found packages with unpatched low/negligible vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := generate_description(rpms_with_unpatched_low_neg_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
-warn_unknown_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
-  rpms_with_unknown_vulnerabilities := get_patched_vulnerabilities(input, "Unknown")
-  not count(rpms_with_unknown_vulnerabilities) == 0
+warn_unknown_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
+	rpms_with_unknown_vulnerabilities := get_patched_vulnerabilities(input, "Unknown")
+	not count(rpms_with_unknown_vulnerabilities) == 0
 
-  name := "clair_unknown_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_unknown_vulnerabilities)
-  msg := "Found packages with unknown vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description := generate_description(rpms_with_unknown_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unknown_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_unknown_vulnerabilities)
+	msg := "Found packages with unknown vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	description := generate_description(rpms_with_unknown_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
-warn_unpatched_unknown_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}} |
-  rpms_with_unpatched_unknown_vulnerabilities := get_unpatched_vulnerabilities(input, "Unknown")
-  not count(rpms_with_unpatched_unknown_vulnerabilities) == 0
+warn_unpatched_unknown_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
+	rpms_with_unpatched_unknown_vulnerabilities := get_unpatched_vulnerabilities(input, "Unknown")
+	not count(rpms_with_unpatched_unknown_vulnerabilities) == 0
 
-  name := "clair_unpatched_unknown_vulnerabilities"
-  vulns_num := count_vulnerabilities(rpms_with_unpatched_unknown_vulnerabilities)
-  msg := "Found packages with unpatched unknown vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := generate_description(rpms_with_unpatched_unknown_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "clair_unpatched_unknown_vulnerabilities"
+	vulns_num := count_vulnerabilities(rpms_with_unpatched_unknown_vulnerabilities)
+	msg := "Found packages with unpatched unknown vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := generate_description(rpms_with_unpatched_unknown_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]

--- a/policies/clamav/virus-check.rego
+++ b/policies/clamav/virus-check.rego
@@ -1,7 +1,7 @@
 package required_checks
 
-import future.keywords.in
 import future.keywords.if
+import future.keywords.in
 
 violation_infected_files := [{"msg": msg, "details": {"filename": filename, "virname": virname, "description": description}} |
 	hit := _report.hits[_]
@@ -45,7 +45,7 @@ _report := d if {
 
 	hits := [{"filename": filename, "virname": virname, "is_heuristic": is_heuristic} |
 		some hit in hits_lines
-		regex.match("^\\S+: \\S+ FOUND$", hit)
+		regex.match(`^\S+: \S+ FOUND$`, hit)
 
 		hit_parts := split(hit, " ")
 		filename := substring(hit_parts[0], 0, count(hit_parts[0]) - 1)

--- a/policies/image/deprecated-labels.rego
+++ b/policies/image/deprecated-labels.rego
@@ -1,73 +1,73 @@
 package required_checks
 
-violation_install_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["INSTALL"]
+violation_install_deprecated := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels.INSTALL
 
-  name := "install_label_deprecated"
-  msg := "The INSTALL label is deprecated!"
-  description := "The 'INSTALL' label is deprecated, replace with 'install'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "install_label_deprecated"
+	msg := "The INSTALL label is deprecated!"
+	description := "The 'INSTALL' label is deprecated, replace with 'install'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_architecture_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["Architecture"]
+violation_architecture_deprecated := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels.Architecture
 
-  name := "architecture_label_deprecated"
-  msg := "The Architecture label is deprecated!"
-  description := "The 'Architecture' label is deprecated, replace with 'architecture'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "architecture_label_deprecated"
+	msg := "The Architecture label is deprecated!"
+	description := "The 'Architecture' label is deprecated, replace with 'architecture'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_name_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["Name"]
+violation_name_deprecated := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels.Name
 
-  name := "name_label_deprecated"
-  msg := "The Name label is deprecated!"
-  description := "The 'Name' label is deprecated, replace with 'name'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "name_label_deprecated"
+	msg := "The Name label is deprecated!"
+	description := "The 'Name' label is deprecated, replace with 'name'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_release_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["Release"]
+violation_release_deprecated := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels.Release
 
-  name := "release_label_deprecated"
-  msg := "The Release label is deprecated!"
-  description := "The 'Release' label is deprecated, replace with 'release'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "release_label_deprecated"
+	msg := "The Release label is deprecated!"
+	description := "The 'Release' label is deprecated, replace with 'release'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_uninstall_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["UNINSTALL"]
+violation_uninstall_deprecated := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels.UNINSTALL
 
-  name := "uninstall_label_deprecated"
-  msg := "The UNINSTALL label is deprecated!"
-  description := "The 'UNINSTALL' label is deprecated, replace with 'uninstall'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "uninstall_label_deprecated"
+	msg := "The UNINSTALL label is deprecated!"
+	description := "The 'UNINSTALL' label is deprecated, replace with 'uninstall'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_version_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["Version"]
+violation_version_deprecated := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels.Version
 
-  name := "version_label_deprecated"
-  msg := "The Version label is deprecated!"
-  description := "The 'Version' label is deprecated, replace with 'version'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "version_label_deprecated"
+	msg := "The Version label is deprecated!"
+	description := "The 'Version' label is deprecated, replace with 'version'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_bzcomponent_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["BZComponent"]
+violation_bzcomponent_deprecated := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels.BZComponent
 
-  name := "bzcomponent_label_deprecated"
-  msg := "The BZComponent label is deprecated!"
-  description := "The BZComponent label is deprecated, replace with 'com.redhat.component'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "bzcomponent_label_deprecated"
+	msg := "The BZComponent label is deprecated!"
+	description := "The BZComponent label is deprecated, replace with 'com.redhat.component'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_run_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["RUN"]
+violation_run_deprecated := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels.RUN
 
-  name := "run_label_deprecated"
-  msg := "The RUN label is deprecated!"
-  description := "The 'RUN' label is deprecated, replace with 'run'"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "run_label_deprecated"
+	msg := "The RUN label is deprecated!"
+	description := "The 'RUN' label is deprecated, replace with 'run'"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]

--- a/policies/image/fbc-labels.rego
+++ b/policies/image/fbc-labels.rego
@@ -1,10 +1,10 @@
 package fbc_checks
 
-violation_fbc_dc_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["operators.operatorframework.io.index.configs.v1"]
+violation_fbc_dc_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels["operators.operatorframework.io.index.configs.v1"]
 
-  name := "operators_operatorframework_io_index_configs_v1_label_required"
-  msg := "The 'operators.operatorframework.io.index.configs.v1' label should be defined for FBC image"
-  description := "Should set DC-specific label `operators.operatorframework.io.index.configs.v1` for the location of the DC root directory for FBC image."
-  url := "https://docs.openshift.com/container-platform/4.9/operators/admin/olm-managing-custom-catalogs.html#olm-creating-fb-catalog-image_olm-managing-custom-catalogs"
+	name := "operators_operatorframework_io_index_configs_v1_label_required"
+	msg := "The 'operators.operatorframework.io.index.configs.v1' label should be defined for FBC image"
+	description := "Should set DC-specific label `operators.operatorframework.io.index.configs.v1` for the location of the DC root directory for FBC image."
+	url := "https://docs.openshift.com/container-platform/4.9/operators/admin/olm-managing-custom-catalogs.html#olm-creating-fb-catalog-image_olm-managing-custom-catalogs"
 ]

--- a/policies/image/inherited-labels.rego
+++ b/policies/image/inherited-labels.rego
@@ -2,47 +2,47 @@ package optional_checks
 
 import data as base_image
 
-violation_summary_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["summary"] == base_image.Labels["summary"]
+violation_summary_label_inherited := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels.summary == base_image.Labels.summary
 
-  name := "summary_label_inherited"
-  msg := "The 'summary' label should not be inherited from the base image"
-  description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
+	name := "summary_label_inherited"
+	msg := "The 'summary' label should not be inherited from the base image"
+	description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
 ]
 
-violation_description_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["description"] == base_image.Labels["description"]
+violation_description_label_inherited := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels.description == base_image.Labels.description
 
-  name := "description_label_inherited"
-  msg := "The 'description' label should not be inherited from the base image"
-  description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
+	name := "description_label_inherited"
+	msg := "The 'description' label should not be inherited from the base image"
+	description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
 ]
 
-violation_io_k8s_description_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["io.k8s.description"] == base_image.Labels["io.k8s.description"]
+violation_io_k8s_description_label_inherited := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels["io.k8s.description"] == base_image.Labels["io.k8s.description"]
 
-  name := "io_k8s_description_label_inherited"
-  msg := "The 'io.k8s.description' label should not be inherited from the base image"
-  description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
+	name := "io_k8s_description_label_inherited"
+	msg := "The 'io.k8s.description' label should not be inherited from the base image"
+	description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
 ]
 
-violation_io_k8s_display_name_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["io.k8s.display-name"] == base_image.Labels["io.k8s.display-name"]
+violation_io_k8s_display_name_label_inherited := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels["io.k8s.display-name"] == base_image.Labels["io.k8s.display-name"]
 
-  name := "io_k8s_display_name_label_inherited"
-  msg := "The 'io.k8s.display-name' label should not be inherited from the base image"
-  description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
+	name := "io_k8s_display_name_label_inherited"
+	msg := "The 'io.k8s.display-name' label should not be inherited from the base image"
+	description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
 ]
 
-violation_io_openshift_tags_label_inherited := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.Labels["io.openshift.tags"] == base_image.Labels["io.openshift.tags"]
+violation_io_openshift_tags_label_inherited := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.Labels["io.openshift.tags"] == base_image.Labels["io.openshift.tags"]
 
-  name := "io_openshift_tags_label_inherited"
-  msg := "The 'io.openshift.tags' label should not be inherited from the base image"
-  description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
+	name := "io_openshift_tags_label_inherited"
+	msg := "The 'io.openshift.tags' label should not be inherited from the base image"
+	description := "If the label is inherited from the base image but not specified in the Dockerfile, it will contain an incorrect value for the built image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#anchor_b2ba2cc8-61f4-ea11-80ed-000d3a020feb"
 ]

--- a/policies/image/optional-labels.rego
+++ b/policies/image/optional-labels.rego
@@ -1,20 +1,19 @@
 package optional_checks
 
+violation_maintainer_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels.maintainer
 
-violation_maintainer_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["maintainer"]
-
-  name := "maintainer_label_required"
-  msg := "The 'maintainer' label should be defined"
-  description := "The name and email of the maintainer (usually the submitter). Should contain `@redhat.com` or `Red Hat`."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "maintainer_label_required"
+	msg := "The 'maintainer' label should be defined"
+	description := "The name and email of the maintainer (usually the submitter). Should contain `@redhat.com` or `Red Hat`."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_summary_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["summary"]
+violation_summary_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels.summary
 
-  name := "summary_label_required"
-  msg := "The 'summary' label should be defined"
-  description := "A short description of the image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "summary_label_required"
+	msg := "The 'summary' label should be defined"
+	description := "A short description of the image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]

--- a/policies/image/required-labels.rego
+++ b/policies/image/required-labels.rego
@@ -1,119 +1,118 @@
 package required_checks
 
+violation_name_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels.name
 
-violation_name_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["name"]
-
-  name := "name_label_required"
-  msg := "The required 'name' label is missing!"
-  description := "Name of the Image or Container."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "name_label_required"
+	msg := "The required 'name' label is missing!"
+	description := "Name of the Image or Container."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_com_redhat_component_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["com.redhat.component"]
+violation_com_redhat_component_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels["com.redhat.component"]
 
-  name := "com_redhat_component_label_required!"
-  msg := "The required 'com.redhat.component' label is missing"
-  description := "The Bugzilla component name where bugs against this container should be reported by users."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "com_redhat_component_label_required!"
+	msg := "The required 'com.redhat.component' label is missing"
+	description := "The Bugzilla component name where bugs against this container should be reported by users."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_version_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["version"]
+violation_version_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels.version
 
-  name := "version_label_required"
-  msg := "The required 'version' label is missing!"
-  description := "Version of the image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "version_label_required"
+	msg := "The required 'version' label is missing!"
+	description := "Version of the image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_description_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["description"]
+violation_description_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels.description
 
-  name := "description_label_required"
-  msg := "The required 'description' label is missing!"
-  description := "Detailed description of the image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "description_label_required"
+	msg := "The required 'description' label is missing!"
+	description := "Detailed description of the image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_io_k8s_description_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["io.k8s.description"]
+violation_io_k8s_description_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels["io.k8s.description"]
 
-  name := "io_k8s_description_label_required"
-  msg := "The required 'io.k8s.description' label is missing!"
-  description := "Description of the container displayed in Kubernetes."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "io_k8s_description_label_required"
+	msg := "The required 'io.k8s.description' label is missing!"
+	description := "Description of the container displayed in Kubernetes."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_vcs_ref_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["vcs-ref"]
+violation_vcs_ref_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels["vcs-ref"]
 
-  name := "vcs_ref_label_required"
-  msg := "The required 'vcs-ref' label is missing!"
-  description := "A 'reference' within the version control repository; e.g. a git commit, or a subversion branch."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "vcs_ref_label_required"
+	msg := "The required 'vcs-ref' label is missing!"
+	description := "A 'reference' within the version control repository; e.g. a git commit, or a subversion branch."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_vcs_type_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["vcs-type"]
+violation_vcs_type_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels["vcs-type"]
 
-  name := "vcs_type_label_required"
-  msg := "The required 'vcs-type' label is missing!"
-  description := "The type of version control used by the container source. Generally one of git, hg, svn, bzr, cvs"
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "vcs_type_label_required"
+	msg := "The required 'vcs-type' label is missing!"
+	description := "The type of version control used by the container source. Generally one of git, hg, svn, bzr, cvs"
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_architecture_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["architecture"]
+violation_architecture_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels.architecture
 
-  name := "architecture_label_required"
-  msg := "The required 'architecture' label is missing!"
-  description := "Architecture the software in the image should target."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "architecture_label_required"
+	msg := "The required 'architecture' label is missing!"
+	description := "Architecture the software in the image should target."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_vendor_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["vendor"]
+violation_vendor_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels.vendor
 
-  name := "vendor_label_required"
-  msg := "The required 'vendor' label is missing!"
-  description := "Name of the vendor."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "vendor_label_required"
+	msg := "The required 'vendor' label is missing!"
+	description := "Name of the vendor."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_release_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["release"]
+violation_release_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels.release
 
-  name := "release_label_required"
-  msg := "The required 'release' label is missing!"
-  description := "Release Number for this version."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "release_label_required"
+	msg := "The required 'release' label is missing!"
+	description := "Release Number for this version."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_url_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["url"]
+violation_url_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels.url
 
-  name := "url_label_required"
-  msg := "The required 'url' label is missing!"
-  description := "A URL where the user can find more information about the image."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "url_label_required"
+	msg := "The required 'url' label is missing!"
+	description := "A URL where the user can find more information about the image."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_build_date_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["build-date"]
+violation_build_date_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels["build-date"]
 
-  name := "build_date_label_required"
-  msg := "The required 'build-date' label is missing!"
-  description := "Date/Time image was built as RFC 3339 date-time."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "build_date_label_required"
+	msg := "The required 'build-date' label is missing!"
+	description := "Date/Time image was built as RFC 3339 date-time."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]
 
-violation_distribution_scope_required := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  not input.Labels["distribution-scope"]
+violation_distribution_scope_required := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	not input.Labels["distribution-scope"]
 
-  name := "distribution_scope_label_required"
-  msg := "The required 'distribution-scope' label is missing!"
-  description := "Scope of intended distribution of the image. (private/authoritative-source-only/restricted/public)."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
+	name := "distribution_scope_label_required"
+	msg := "The required 'distribution-scope' label is missing!"
+	description := "Scope of intended distribution of the image. (private/authoritative-source-only/restricted/public)."
+	url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 ]

--- a/policies/picklescan/virus-check.rego
+++ b/policies/picklescan/virus-check.rego
@@ -1,7 +1,7 @@
 package required_checks
 
-import future.keywords.in
 import future.keywords.if
+import future.keywords.in
 
 violation_picklescan_infected_files := [{"msg": msg, "details": {"filename": filename, "finding": finding}} |
 	some filename, finding in input.infected_files

--- a/policies/repository/deprecated-image.rego
+++ b/policies/repository/deprecated-image.rego
@@ -1,11 +1,10 @@
 package required_checks
 
+violation_image_repository_deprecated := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	input.release_categories[_] == "Deprecated"
 
-violation_image_repository_deprecated := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  input.release_categories[_] == "Deprecated"
-
-  name := "image_repository_deprecated"
-  msg := "The container image shouldn't be built from a repository that is marked as 'Deprecated' in Red Hat Catalog."
-  description := "Deprecated images are no longer maintained and will accumulate security vulnerabilities without releasing a fixed version."
-  url := "https://redhat-connect.gitbook.io/catalog-help/container-images/container-image-details/container-image-release-categories"
+	name := "image_repository_deprecated"
+	msg := "The container image shouldn't be built from a repository that is marked as 'Deprecated' in Red Hat Catalog."
+	description := "Deprecated images are no longer maintained and will accumulate security vulnerabilities without releasing a fixed version."
+	url := "https://redhat-connect.gitbook.io/catalog-help/container-images/container-image-details/container-image-release-categories"
 ]

--- a/policies/rhtpa/vulnerabilities-check.rego
+++ b/policies/rhtpa/vulnerabilities-check.rego
@@ -4,11 +4,11 @@ import future.keywords.if
 
 # Get direct vulnerabilities of a given severity from a source
 rhtpa_get_direct_vulns(source, severity) := vulns if {
-  vulns := [{"ref": dep.ref, "issues": filtered} |
-    dep := source.dependencies[_]
-    filtered := [issue | issue := dep.issues[_]; issue.severity == severity]
-    count(filtered) > 0
-  ]
+	vulns := [{"ref": dep.ref, "issues": filtered} |
+		dep := source.dependencies[_]
+		filtered := [issue | issue := dep.issues[_]; issue.severity == severity]
+		count(filtered) > 0
+	]
 }
 
 # Get transitive vulnerabilities of a given severity from a source.
@@ -17,104 +17,105 @@ rhtpa_get_direct_vulns(source, severity) := vulns if {
 # transitive). Each transitive entry is tracked with its parent_ref so the
 # description can show the dependency chain.
 rhtpa_get_transitive_vulns(source, severity) := vulns if {
-  vulns := [{"ref": tdep.ref, "parent_ref": dep.ref, "issues": filtered} |
-    dep := source.dependencies[_]
-    tdep := dep.transitive[_]
-    filtered := [issue | issue := tdep.issues[_]; issue.severity == severity]
-    count(filtered) > 0
-  ]
+	vulns := [{"ref": tdep.ref, "parent_ref": dep.ref, "issues": filtered} |
+		dep := source.dependencies[_]
+		tdep := dep.transitive[_]
+		filtered := [issue | issue := tdep.issues[_]; issue.severity == severity]
+		count(filtered) > 0
+	]
 }
 
 # Format description string from direct and transitive vulnerability entries
 rhtpa_generate_description(source_name, direct, transitive) := dsc if {
-  direct_descs := [sprintf("%s [direct] (%s)", [v.ref, concat(", ", [i.id | i := v.issues[_]])]) | v := direct[_]]
-  transitive_descs := [sprintf("%s [transitive via %s] (%s)", [v.ref, v.parent_ref, concat(", ", [i.id | i := v.issues[_]])]) | v := transitive[_]]
-  all_descs := array.concat(direct_descs, transitive_descs)
-  dsc := sprintf("Source: %s. Affected dependencies: %s", [source_name, concat(", ", all_descs)])
+	direct_descs := [sprintf("%s [direct] (%s)", [v.ref, concat(", ", [i.id | i := v.issues[_]])]) | v := direct[_]]
+	transitive_descs := [sprintf("%s [transitive via %s] (%s)", [v.ref, v.parent_ref, concat(", ", [i.id | i := v.issues[_]])]) | v := transitive[_]]
+	all_descs := array.concat(direct_descs, transitive_descs)
+	dsc := sprintf("Source: %s. Affected dependencies: %s", [source_name, concat(", ", all_descs)])
 }
 
 # Pluralize "vulnerability"
-rhtpa_pluralize(n) = "vulnerability" { n == 1 }
-rhtpa_pluralize(n) = "vulnerabilities" { n != 1 }
+rhtpa_pluralize(n) := "vulnerability" if n == 1
+
+rhtpa_pluralize(n) := "vulnerabilities" if n != 1
 
 # Collect unique CVE IDs across all sources for a given severity
 rhtpa_unique_cve_ids(severity) := ids if {
-  direct_ids := {issue.id |
-    some source_name
-    source := input.providers.rhtpa.sources[source_name]
-    dep := source.dependencies[_]
-    issue := dep.issues[_]
-    issue.severity == severity
-  }
-  transitive_ids := {issue.id |
-    some source_name
-    source := input.providers.rhtpa.sources[source_name]
-    dep := source.dependencies[_]
-    tdep := dep.transitive[_]
-    issue := tdep.issues[_]
-    issue.severity == severity
-  }
-  ids := direct_ids | transitive_ids
+	direct_ids := {issue.id |
+		some source_name
+		source := input.providers.rhtpa.sources[source_name]
+		dep := source.dependencies[_]
+		issue := dep.issues[_]
+		issue.severity == severity
+	}
+	transitive_ids := {issue.id |
+		some source_name
+		source := input.providers.rhtpa.sources[source_name]
+		dep := source.dependencies[_]
+		tdep := dep.transitive[_]
+		issue := tdep.issues[_]
+		issue.severity == severity
+	}
+	ids := direct_ids | transitive_ids
 }
 
 # Concatenate per-source descriptions for a given severity
 rhtpa_source_descriptions(severity) := desc if {
-  descs := [d |
-    some source_name
-    source := input.providers.rhtpa.sources[source_name]
-    direct := rhtpa_get_direct_vulns(source, severity)
-    transitive := rhtpa_get_transitive_vulns(source, severity)
-    all_vulns := array.concat(direct, transitive)
-    count(all_vulns) > 0
-    d := rhtpa_generate_description(source_name, direct, transitive)
-  ]
-  desc := concat("; ", descs)
+	descs := [d |
+		some source_name
+		source := input.providers.rhtpa.sources[source_name]
+		direct := rhtpa_get_direct_vulns(source, severity)
+		transitive := rhtpa_get_transitive_vulns(source, severity)
+		all_vulns := array.concat(direct, transitive)
+		count(all_vulns) > 0
+		d := rhtpa_generate_description(source_name, direct, transitive)
+	]
+	desc := concat("; ", descs)
 }
 
 default warn_rhtpa_critical_vulnerabilities := []
 
 warn_rhtpa_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}}] if {
-  unique_ids := rhtpa_unique_cve_ids("CRITICAL")
-  vulns_num := count(unique_ids)
-  vulns_num > 0
-  name := "rhtpa_critical_vulnerabilities"
-  msg := sprintf("Found %d critical %s.", [vulns_num, rhtpa_pluralize(vulns_num)])
-  description := rhtpa_source_descriptions("CRITICAL")
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	unique_ids := rhtpa_unique_cve_ids("CRITICAL")
+	vulns_num := count(unique_ids)
+	vulns_num > 0
+	name := "rhtpa_critical_vulnerabilities"
+	msg := sprintf("Found %d critical %s.", [vulns_num, rhtpa_pluralize(vulns_num)])
+	description := rhtpa_source_descriptions("CRITICAL")
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
 default warn_rhtpa_high_vulnerabilities := []
 
 warn_rhtpa_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}}] if {
-  unique_ids := rhtpa_unique_cve_ids("HIGH")
-  vulns_num := count(unique_ids)
-  vulns_num > 0
-  name := "rhtpa_high_vulnerabilities"
-  msg := sprintf("Found %d high %s.", [vulns_num, rhtpa_pluralize(vulns_num)])
-  description := rhtpa_source_descriptions("HIGH")
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	unique_ids := rhtpa_unique_cve_ids("HIGH")
+	vulns_num := count(unique_ids)
+	vulns_num > 0
+	name := "rhtpa_high_vulnerabilities"
+	msg := sprintf("Found %d high %s.", [vulns_num, rhtpa_pluralize(vulns_num)])
+	description := rhtpa_source_descriptions("HIGH")
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
 default warn_rhtpa_medium_vulnerabilities := []
 
 warn_rhtpa_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}}] if {
-  unique_ids := rhtpa_unique_cve_ids("MEDIUM")
-  vulns_num := count(unique_ids)
-  vulns_num > 0
-  name := "rhtpa_medium_vulnerabilities"
-  msg := sprintf("Found %d medium %s.", [vulns_num, rhtpa_pluralize(vulns_num)])
-  description := rhtpa_source_descriptions("MEDIUM")
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	unique_ids := rhtpa_unique_cve_ids("MEDIUM")
+	vulns_num := count(unique_ids)
+	vulns_num > 0
+	name := "rhtpa_medium_vulnerabilities"
+	msg := sprintf("Found %d medium %s.", [vulns_num, rhtpa_pluralize(vulns_num)])
+	description := rhtpa_source_descriptions("MEDIUM")
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
 default warn_rhtpa_low_vulnerabilities := []
 
 warn_rhtpa_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}}] if {
-  unique_ids := rhtpa_unique_cve_ids("LOW")
-  vulns_num := count(unique_ids)
-  vulns_num > 0
-  name := "rhtpa_low_vulnerabilities"
-  msg := sprintf("Found %d low %s.", [vulns_num, rhtpa_pluralize(vulns_num)])
-  description := rhtpa_source_descriptions("LOW")
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	unique_ids := rhtpa_unique_cve_ids("LOW")
+	vulns_num := count(unique_ids)
+	vulns_num > 0
+	name := "rhtpa_low_vulnerabilities"
+	msg := sprintf("Found %d low %s.", [vulns_num, rhtpa_pluralize(vulns_num)])
+	description := rhtpa_source_descriptions("LOW")
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }

--- a/policies/roxctl/vulnerabilities-check.rego
+++ b/policies/roxctl/vulnerabilities-check.rego
@@ -10,153 +10,153 @@ import future.keywords.in
 # LOW_VULNERABILITY_SEVERITY -> Low
 
 roxctl_has_rhsa_advisory(advisories) if {
-  some a in advisories
-  contains(a.name, "RHSA")
+	some a in advisories
+	contains(a.name, "RHSA")
 }
 
 roxctl_get_patched_vulnerabilities(input_data, severity) := vulnerabilities if {
-  vulnerabilities := [entry |
-    v := input_data[_]
-    v.severity == severity
-    v.fixedBy != ""
-    count(v.advisory) > 0
-    roxctl_has_rhsa_advisory(v.advisory)
-    entry := {"cve": v.cve, "components": v.components, "fixedBy": v.fixedBy}
-  ]
+	vulnerabilities := [entry |
+		v := input_data[_]
+		v.severity == severity
+		v.fixedBy != ""
+		count(v.advisory) > 0
+		roxctl_has_rhsa_advisory(v.advisory)
+		entry := {"cve": v.cve, "components": v.components, "fixedBy": v.fixedBy}
+	]
 }
 
 roxctl_get_unpatched_vulnerabilities(input_data, severity) := vulnerabilities if {
-  vulnerabilities := [entry |
-    v := input_data[_]
-    v.severity == severity
-    v.fixedBy == ""
-    count(v.advisory) == 0
-    entry := {"cve": v.cve, "components": v.components}
-  ]
+	vulnerabilities := [entry |
+		v := input_data[_]
+		v.severity == severity
+		v.fixedBy == ""
+		count(v.advisory) == 0
+		entry := {"cve": v.cve, "components": v.components}
+	]
 }
 
 roxctl_get_discrepancies(input_data) := disc if {
-  disc := [entry |
-    v := input_data[_]
-    v.severity != ""
-    not roxctl_has_redhat_link(v.links)
-    entry := {"cve": v.cve, "components": v.components, "links": v.links}
-  ]
+	disc := [entry |
+		v := input_data[_]
+		v.severity != ""
+		not roxctl_has_redhat_link(v.links)
+		entry := {"cve": v.cve, "components": v.components, "links": v.links}
+	]
 }
 
 roxctl_has_redhat_link(links) if {
-  some link in links
-  contains(link, "redhat")
+	some link in links
+	contains(link, "redhat")
 }
 
 roxctl_count_vulnerabilities(vulnerabilities) := count(vulnerabilities)
 
 roxctl_format_components(components) := formatted if {
-  formatted := concat(", ", [sprintf("%s-%s@%s", [c.component, c.version, c.source]) | c := components[_]])
+	formatted := concat(", ", [sprintf("%s-%s@%s", [c.component, c.version, c.source]) | c := components[_]])
 }
 
 roxctl_generate_description(vulnerabilities) := dsc if {
-  dsc := sprintf("Vulnerabilities found: %s", [concat(", ",
-    [sprintf("%s: %s", [v.cve, roxctl_format_components(v.components)]) | v := vulnerabilities[_]]
-  )])
+	dsc := sprintf("Vulnerabilities found: %s", [concat(
+		", ",
+		[sprintf("%s: %s", [v.cve, roxctl_format_components(v.components)]) | v := vulnerabilities[_]],
+	)])
 }
 
-
 warn_roxctl_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_critical_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "CRITICAL_VULNERABILITY_SEVERITY")
-  not count(components_with_critical_vulnerabilities) == 0
+	components_with_critical_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "CRITICAL_VULNERABILITY_SEVERITY")
+	not count(components_with_critical_vulnerabilities) == 0
 
-  name := "roxctl_critical_vulnerabilities"
-  vulns_num := roxctl_count_vulnerabilities(components_with_critical_vulnerabilities)
-  msg := "Found components with critical vulnerabilities that have available fixes. Consider updating to a newer version of those components."
-  description := roxctl_generate_description(components_with_critical_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "roxctl_critical_vulnerabilities"
+	vulns_num := roxctl_count_vulnerabilities(components_with_critical_vulnerabilities)
+	msg := "Found components with critical vulnerabilities that have available fixes. Consider updating to a newer version of those components."
+	description := roxctl_generate_description(components_with_critical_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
 warn_roxctl_unpatched_critical_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_unpatched_critical_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "CRITICAL_VULNERABILITY_SEVERITY")
-  not count(components_with_unpatched_critical_vulnerabilities) == 0
+	components_with_unpatched_critical_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "CRITICAL_VULNERABILITY_SEVERITY")
+	not count(components_with_unpatched_critical_vulnerabilities) == 0
 
-  name := "roxctl_unpatched_critical_vulnerabilities"
-  vulns_num := roxctl_count_vulnerabilities(components_with_unpatched_critical_vulnerabilities)
-  msg := "Found components with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := roxctl_generate_description(components_with_unpatched_critical_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "roxctl_unpatched_critical_vulnerabilities"
+	vulns_num := roxctl_count_vulnerabilities(components_with_unpatched_critical_vulnerabilities)
+	msg := "Found components with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := roxctl_generate_description(components_with_unpatched_critical_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
 warn_roxctl_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_high_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "IMPORTANT_VULNERABILITY_SEVERITY")
-  not count(components_with_high_vulnerabilities) == 0
+	components_with_high_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "IMPORTANT_VULNERABILITY_SEVERITY")
+	not count(components_with_high_vulnerabilities) == 0
 
-  name := "roxctl_high_vulnerabilities"
-  vulns_num := roxctl_count_vulnerabilities(components_with_high_vulnerabilities)
-  msg := "Found components with high vulnerabilities that have available fixes. Consider updating to a newer version of those components."
-  description := roxctl_generate_description(components_with_high_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "roxctl_high_vulnerabilities"
+	vulns_num := roxctl_count_vulnerabilities(components_with_high_vulnerabilities)
+	msg := "Found components with high vulnerabilities that have available fixes. Consider updating to a newer version of those components."
+	description := roxctl_generate_description(components_with_high_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
 warn_roxctl_unpatched_high_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_unpatched_high_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "IMPORTANT_VULNERABILITY_SEVERITY")
-  not count(components_with_unpatched_high_vulnerabilities) == 0
+	components_with_unpatched_high_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "IMPORTANT_VULNERABILITY_SEVERITY")
+	not count(components_with_unpatched_high_vulnerabilities) == 0
 
-  name := "roxctl_unpatched_high_vulnerabilities"
-  vulns_num := roxctl_count_vulnerabilities(components_with_unpatched_high_vulnerabilities)
-  msg := "Found components with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := roxctl_generate_description(components_with_unpatched_high_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "roxctl_unpatched_high_vulnerabilities"
+	vulns_num := roxctl_count_vulnerabilities(components_with_unpatched_high_vulnerabilities)
+	msg := "Found components with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := roxctl_generate_description(components_with_unpatched_high_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
 warn_roxctl_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_medium_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "MODERATE_VULNERABILITY_SEVERITY")
-  not count(components_with_medium_vulnerabilities) == 0
+	components_with_medium_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "MODERATE_VULNERABILITY_SEVERITY")
+	not count(components_with_medium_vulnerabilities) == 0
 
-  name := "roxctl_medium_vulnerabilities"
-  vulns_num := roxctl_count_vulnerabilities(components_with_medium_vulnerabilities)
-  msg := "Found components with medium vulnerabilities that have available fixes. Consider updating to a newer version of those components."
-  description := roxctl_generate_description(components_with_medium_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "roxctl_medium_vulnerabilities"
+	vulns_num := roxctl_count_vulnerabilities(components_with_medium_vulnerabilities)
+	msg := "Found components with medium vulnerabilities that have available fixes. Consider updating to a newer version of those components."
+	description := roxctl_generate_description(components_with_medium_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
 warn_roxctl_unpatched_medium_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_unpatched_medium_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "MODERATE_VULNERABILITY_SEVERITY")
-  not count(components_with_unpatched_medium_vulnerabilities) == 0
+	components_with_unpatched_medium_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "MODERATE_VULNERABILITY_SEVERITY")
+	not count(components_with_unpatched_medium_vulnerabilities) == 0
 
-  name := "roxctl_unpatched_medium_vulnerabilities"
-  vulns_num := roxctl_count_vulnerabilities(components_with_unpatched_medium_vulnerabilities)
-  msg := "Found components with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := roxctl_generate_description(components_with_unpatched_medium_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "roxctl_unpatched_medium_vulnerabilities"
+	vulns_num := roxctl_count_vulnerabilities(components_with_unpatched_medium_vulnerabilities)
+	msg := "Found components with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := roxctl_generate_description(components_with_unpatched_medium_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
 warn_roxctl_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_low_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "LOW_VULNERABILITY_SEVERITY")
-  not count(components_with_low_vulnerabilities) == 0
+	components_with_low_vulnerabilities := roxctl_get_patched_vulnerabilities(input, "LOW_VULNERABILITY_SEVERITY")
+	not count(components_with_low_vulnerabilities) == 0
 
-  name := "roxctl_low_vulnerabilities"
-  vulns_num := roxctl_count_vulnerabilities(components_with_low_vulnerabilities)
-  msg := "Found components with low vulnerabilities that have available fixes. Consider updating to a newer version of those components."
-  description := roxctl_generate_description(components_with_low_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "roxctl_low_vulnerabilities"
+	vulns_num := roxctl_count_vulnerabilities(components_with_low_vulnerabilities)
+	msg := "Found components with low vulnerabilities that have available fixes. Consider updating to a newer version of those components."
+	description := roxctl_generate_description(components_with_low_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
 warn_roxctl_unpatched_low_vulnerabilities := [{"msg": msg, "vulnerabilities_number": vulns_num, "details": {"name": name, "description": description, "url": url}} |
-  components_with_unpatched_low_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "LOW_VULNERABILITY_SEVERITY")
-  not count(components_with_unpatched_low_vulnerabilities) == 0
+	components_with_unpatched_low_vulnerabilities := roxctl_get_unpatched_vulnerabilities(input, "LOW_VULNERABILITY_SEVERITY")
+	not count(components_with_unpatched_low_vulnerabilities) == 0
 
-  name := "roxctl_unpatched_low_vulnerabilities"
-  vulns_num := roxctl_count_vulnerabilities(components_with_unpatched_low_vulnerabilities)
-  msg := "Found components with unpatched low vulnerabilities. These vulnerabilities don't have a known fix at this time."
-  description := roxctl_generate_description(components_with_unpatched_low_vulnerabilities)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "roxctl_unpatched_low_vulnerabilities"
+	vulns_num := roxctl_count_vulnerabilities(components_with_unpatched_low_vulnerabilities)
+	msg := "Found components with unpatched low vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	description := roxctl_generate_description(components_with_unpatched_low_vulnerabilities)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]
 
 discrepancies_for_cves := [{"msg": msg, "discrepancies_number": disc_num, "details": {"name": name, "description": description, "url": url}} |
-  cves_with_discrepancies := roxctl_get_discrepancies(input)
-  not count(cves_with_discrepancies) == 0
+	cves_with_discrepancies := roxctl_get_discrepancies(input)
+	not count(cves_with_discrepancies) == 0
 
-  name := "discrepancies"
-  disc_num := roxctl_count_vulnerabilities(cves_with_discrepancies)
-  msg := "Found cves with discrepancies."
-  description := roxctl_generate_description(cves_with_discrepancies)
-  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
+	name := "discrepancies"
+	disc_num := roxctl_count_vulnerabilities(cves_with_discrepancies)
+	msg := "Found cves with discrepancies."
+	description := roxctl_generate_description(cves_with_discrepancies)
+	url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 ]

--- a/policies/rpm_manifest/unsigned-rpms.rego
+++ b/policies/rpm_manifest/unsigned-rpms.rego
@@ -1,12 +1,11 @@
 package required_checks
 
+violation_image_unsigned_rpms := [{"msg": msg, "details": {"name": name, "description": description, "url": url}} |
+	unsigned_rpms := {rpm.nvra | rpm := input.rpms[_]; not rpm.gpg}
+	not count(unsigned_rpms) == 0
 
-violation_image_unsigned_rpms := [{"msg": msg, "details":{"name": name, "description": description, "url": url}} |
-  unsigned_rpms := {rpm.nvra | rpm := input.rpms[_]; not rpm.gpg}
-  not count(unsigned_rpms) == 0
-
-  name := "image_unsigned_rpms"
-  msg = sprintf("All RPMs found on the image must be signed. Found following unsigned rpms(nvra): %s", [concat(", ", unsigned_rpms)])
-  description := "Providing packages signed with the secure Red Hat signing server indicates that the package was subject to all appropriate policies and procedures."
-  url := "https://docs.engineering.redhat.com/display/PRODSEC/PSP4.0+-+Offerings+Built+Securely"
+	name := "image_unsigned_rpms"
+	msg := sprintf("All RPMs found on the image must be signed. Found following unsigned rpms(nvra): %s", [concat(", ", unsigned_rpms)])
+	description := "Providing packages signed with the secure Red Hat signing server indicates that the package was subject to all appropriate policies and procedures."
+	url := "https://docs.engineering.redhat.com/display/PRODSEC/PSP4.0+-+Offerings+Built+Securely"
 ]

--- a/unittests/test_clair/vulnerabilities-check_test.rego
+++ b/unittests/test_clair/vulnerabilities-check_test.rego
@@ -1,74 +1,74 @@
 package required_checks
 
-import data.clair as clair
+import data.clair
 import future.keywords.if
 
 test_warn_critical_vulnerabilities if {
-    result := warn_critical_vulnerabilities with input as clair
-    result[_].details.name == "clair_critical_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with critical vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	result := warn_critical_vulnerabilities with input as clair
+	result[_].details.name == "clair_critical_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with critical vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
 test_warn_unpatched_critical_vulnerabilities if {
-    result := warn_unpatched_critical_vulnerabilities with input as clair
-    result[_].details.name == "clair_unpatched_critical_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	result := warn_unpatched_critical_vulnerabilities with input as clair
+	result[_].details.name == "clair_unpatched_critical_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
 test_warn_high_vulnerabilities if {
-    result := warn_high_vulnerabilities with input as clair
-    result[_].details.name == "clair_high_vulnerabilities"
-    result[_].vulnerabilities_number == 2
-    result[_].msg == "Found packages with high vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	result := warn_high_vulnerabilities with input as clair
+	result[_].details.name == "clair_high_vulnerabilities"
+	result[_].vulnerabilities_number == 2
+	result[_].msg == "Found packages with high vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
 test_warn_unpatched_high_vulnerabilities if {
-    result := warn_unpatched_high_vulnerabilities with input as clair
-    result[_].details.name == "clair_unpatched_high_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	result := warn_unpatched_high_vulnerabilities with input as clair
+	result[_].details.name == "clair_unpatched_high_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
 test_warn_medium_vulnerabilities if {
-    result := warn_medium_vulnerabilities with input as clair
-    result[_].details.name == "clair_medium_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with medium vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	result := warn_medium_vulnerabilities with input as clair
+	result[_].details.name == "clair_medium_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with medium vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
 test_warn_unpatched_medium_vulnerabilities if {
-    result := warn_unpatched_medium_vulnerabilities with input as clair
-    result[_].details.name == "clair_unpatched_medium_vulnerabilities"
-    result[_].vulnerabilities_number == 2
-    result[_].msg == "Found packages with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	result := warn_unpatched_medium_vulnerabilities with input as clair
+	result[_].details.name == "clair_unpatched_medium_vulnerabilities"
+	result[_].vulnerabilities_number == 2
+	result[_].msg == "Found packages with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
 test_warn_low_vulnerabilities if {
-    result := warn_low_vulnerabilities with input as clair
-    result[_].details.name == "clair_low_vulnerabilities"
-    result[_].vulnerabilities_number == 2
-    result[_].msg == "Found packages with low/negligible vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	result := warn_low_vulnerabilities with input as clair
+	result[_].details.name == "clair_low_vulnerabilities"
+	result[_].vulnerabilities_number == 2
+	result[_].msg == "Found packages with low/negligible vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
 test_warn_unpatched_low_vulnerabilities if {
-    result := warn_unpatched_low_vulnerabilities with input as clair
-    result[_].details.name == "clair_unpatched_low_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with unpatched low/negligible vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	result := warn_unpatched_low_vulnerabilities with input as clair
+	result[_].details.name == "clair_unpatched_low_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with unpatched low/negligible vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
 test_warn_unknown_vulnerabilities if {
-    result := warn_unknown_vulnerabilities with input as clair
-    result[_].details.name == "clair_unknown_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with unknown vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+	result := warn_unknown_vulnerabilities with input as clair
+	result[_].details.name == "clair_unknown_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with unknown vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
 test_warn_unpatched_unknown_vulnerabilities if {
-    result := warn_unpatched_unknown_vulnerabilities with input as clair
-    result[_].details.name == "clair_unpatched_unknown_vulnerabilities"
-    result[_].vulnerabilities_number == 1
-    result[_].msg == "Found packages with unpatched unknown vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	result := warn_unpatched_unknown_vulnerabilities with input as clair
+	result[_].details.name == "clair_unpatched_unknown_vulnerabilities"
+	result[_].vulnerabilities_number == 1
+	result[_].msg == "Found packages with unpatched unknown vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }

--- a/unittests/test_clamav/virus-check_test.rego
+++ b/unittests/test_clamav/virus-check_test.rego
@@ -1,19 +1,18 @@
 package required_checks
 
-import future.keywords.in
 import future.keywords.if
+import future.keywords.in
 
 import data.clamav_output as clamav
 
-
 test_violation_infected_files if {
-    result := violation_infected_files with input as clamav
-    result[_].msg == "Detected malware 'Win.Test.EICAR_HDB-1' in /tmp/test/eicar.txt"
+	result := violation_infected_files with input as clamav
+	result[_].msg == "Detected malware 'Win.Test.EICAR_HDB-1' in /tmp/test/eicar.txt"
 }
 
 test_warn_heuristic_malware_files if {
-    result := warn_heuristic_malware_files with input as clamav
-    result[0].msg == "Detected potential malware 'Heuristics.Limits.Exceeded.MaxFileSize' by heuristics in /tmp/giant-file.a"
-    result[1].msg == "Detected potential malware 'Heuristics.Limits.Exceeded.MaxFileSize' by heuristics in /tmp/giant.db"
-    result[2].msg == "Detected potential malware 'Heuristics.Broken.Executable' by heuristics in /work/content/usr/lib/firmware/ath11k/IPQ5018/hw1.0/m3_fw.b00.xz"
+	result := warn_heuristic_malware_files with input as clamav
+	result[0].msg == "Detected potential malware 'Heuristics.Limits.Exceeded.MaxFileSize' by heuristics in /tmp/giant-file.a"
+	result[1].msg == "Detected potential malware 'Heuristics.Limits.Exceeded.MaxFileSize' by heuristics in /tmp/giant.db"
+	result[2].msg == "Detected potential malware 'Heuristics.Broken.Executable' by heuristics in /work/content/usr/lib/firmware/ath11k/IPQ5018/hw1.0/m3_fw.b00.xz"
 }

--- a/unittests/test_images/deprecated-labels_test.rego
+++ b/unittests/test_images/deprecated-labels_test.rego
@@ -5,49 +5,49 @@ import future.keywords.if
 import data.bad_image as image
 
 test_violation_install_deprecated if {
-    result := violation_install_deprecated with input as image
-    result[_].details.name == "install_label_deprecated"
-    result[_].msg == "The INSTALL label is deprecated!"
+	result := violation_install_deprecated with input as image
+	result[_].details.name == "install_label_deprecated"
+	result[_].msg == "The INSTALL label is deprecated!"
 }
 
 test_violation_architecture_deprecated if {
-    result := violation_architecture_deprecated with input as image
-    result[_].details.name == "architecture_label_deprecated"
-    result[_].msg == "The Architecture label is deprecated!"
+	result := violation_architecture_deprecated with input as image
+	result[_].details.name == "architecture_label_deprecated"
+	result[_].msg == "The Architecture label is deprecated!"
 }
 
 test_violation_name_deprecated if {
-    result := violation_name_deprecated with input as image
-    result[_].details.name == "name_label_deprecated"
-    result[_].msg == "The Name label is deprecated!"
+	result := violation_name_deprecated with input as image
+	result[_].details.name == "name_label_deprecated"
+	result[_].msg == "The Name label is deprecated!"
 }
 
 test_violation_release_deprecated if {
-    result := violation_release_deprecated with input as image
-    result[_].details.name == "release_label_deprecated"
-    result[_].msg == "The Release label is deprecated!"
+	result := violation_release_deprecated with input as image
+	result[_].details.name == "release_label_deprecated"
+	result[_].msg == "The Release label is deprecated!"
 }
 
 test_violation_uninstall_deprecated if {
-    result := violation_uninstall_deprecated with input as image
-    result[_].details.name == "uninstall_label_deprecated"
-    result[_].msg == "The UNINSTALL label is deprecated!"
+	result := violation_uninstall_deprecated with input as image
+	result[_].details.name == "uninstall_label_deprecated"
+	result[_].msg == "The UNINSTALL label is deprecated!"
 }
 
 test_violation_version_deprecated if {
-    result := violation_version_deprecated with input as image
-    result[_].details.name == "version_label_deprecated"
-    result[_].msg == "The Version label is deprecated!"
+	result := violation_version_deprecated with input as image
+	result[_].details.name == "version_label_deprecated"
+	result[_].msg == "The Version label is deprecated!"
 }
 
 test_violation_bzcomponent_deprecated if {
-    result := violation_bzcomponent_deprecated with input as image
-    result[_].details.name == "bzcomponent_label_deprecated"
-    result[_].msg == "The BZComponent label is deprecated!"
+	result := violation_bzcomponent_deprecated with input as image
+	result[_].details.name == "bzcomponent_label_deprecated"
+	result[_].msg == "The BZComponent label is deprecated!"
 }
 
 test_violation_run_deprecated if {
-    result := violation_run_deprecated with input as image
-    result[_].details.name == "run_label_deprecated"
-    result[_].msg == "The RUN label is deprecated!"
+	result := violation_run_deprecated with input as image
+	result[_].details.name == "run_label_deprecated"
+	result[_].msg == "The RUN label is deprecated!"
 }

--- a/unittests/test_images/fbc-labels_test.rego
+++ b/unittests/test_images/fbc-labels_test.rego
@@ -5,7 +5,7 @@ import future.keywords.if
 import data.good_image as image
 
 test_violation_fbc_dc_required if {
-    result := violation_fbc_dc_required with input as image
-    result[_].details.name == "operators_operatorframework_io_index_configs_v1_label_required"
-    result[_].msg == "The 'operators.operatorframework.io.index.configs.v1' label should be defined for FBC image"
+	result := violation_fbc_dc_required with input as image
+	result[_].details.name == "operators_operatorframework_io_index_configs_v1_label_required"
+	result[_].msg == "The 'operators.operatorframework.io.index.configs.v1' label should be defined for FBC image"
 }

--- a/unittests/test_images/inherited-labels_test.rego
+++ b/unittests/test_images/inherited-labels_test.rego
@@ -2,35 +2,35 @@ package optional_checks
 
 import future.keywords.if
 
-import data.good_image as image
 import data.good_image as base_image
+import data.good_image as image
 
 test_violation_summary_label_inherited if {
-    result := violation_summary_label_inherited with input as image with data.Labels as base_image.Labels
-    result[_].details.name == "summary_label_inherited"
-    result[_].msg == "The 'summary' label should not be inherited from the base image"
+	result := violation_summary_label_inherited with input as image with data.Labels as base_image.Labels
+	result[_].details.name == "summary_label_inherited"
+	result[_].msg == "The 'summary' label should not be inherited from the base image"
 }
 
 test_violation_description_label_inherited if {
-    result := violation_description_label_inherited with input as image with data.Labels as base_image.Labels
-    result[_].details.name == "description_label_inherited"
-    result[_].msg == "The 'description' label should not be inherited from the base image"
+	result := violation_description_label_inherited with input as image with data.Labels as base_image.Labels
+	result[_].details.name == "description_label_inherited"
+	result[_].msg == "The 'description' label should not be inherited from the base image"
 }
 
 test_violation_io_k8s_description_label_inherited if {
-    result := violation_io_k8s_description_label_inherited with input as image with data.Labels as base_image.Labels
-    result[_].details.name == "io_k8s_description_label_inherited"
-    result[_].msg == "The 'io.k8s.description' label should not be inherited from the base image"
+	result := violation_io_k8s_description_label_inherited with input as image with data.Labels as base_image.Labels
+	result[_].details.name == "io_k8s_description_label_inherited"
+	result[_].msg == "The 'io.k8s.description' label should not be inherited from the base image"
 }
 
 test_violation_io_k8s_display_name_label_inherited if {
-    result := violation_io_k8s_display_name_label_inherited with input as image with data.Labels as base_image.Labels
-    result[_].details.name == "io_k8s_display_name_label_inherited"
-    result[_].msg == "The 'io.k8s.display-name' label should not be inherited from the base image"
+	result := violation_io_k8s_display_name_label_inherited with input as image with data.Labels as base_image.Labels
+	result[_].details.name == "io_k8s_display_name_label_inherited"
+	result[_].msg == "The 'io.k8s.display-name' label should not be inherited from the base image"
 }
 
 test_violation_io_openshift_tags_label_inherited if {
-    result := violation_io_openshift_tags_label_inherited with input as image with data.Labels as base_image.Labels
-    result[_].details.name == "io_openshift_tags_label_inherited"
-    result[_].msg == "The 'io.openshift.tags' label should not be inherited from the base image"
+	result := violation_io_openshift_tags_label_inherited with input as image with data.Labels as base_image.Labels
+	result[_].details.name == "io_openshift_tags_label_inherited"
+	result[_].msg == "The 'io.openshift.tags' label should not be inherited from the base image"
 }

--- a/unittests/test_images/optional-labels_test.rego
+++ b/unittests/test_images/optional-labels_test.rego
@@ -5,13 +5,13 @@ import future.keywords.if
 import data.bad_image as image
 
 test_violation_maintainer_required if {
-    result := violation_maintainer_required with input as image
-    result[_].details.name == "maintainer_label_required"
-    result[_].msg == "The 'maintainer' label should be defined"
+	result := violation_maintainer_required with input as image
+	result[_].details.name == "maintainer_label_required"
+	result[_].msg == "The 'maintainer' label should be defined"
 }
 
 test_violation_summary_required if {
-    result := violation_summary_required with input as image
-    result[_].details.name == "summary_label_required"
-    result[_].msg == "The 'summary' label should be defined"
+	result := violation_summary_required with input as image
+	result[_].details.name == "summary_label_required"
+	result[_].msg == "The 'summary' label should be defined"
 }

--- a/unittests/test_images/required-labels_test.rego
+++ b/unittests/test_images/required-labels_test.rego
@@ -5,79 +5,79 @@ import future.keywords.if
 import data.bad_image as image
 
 test_violation_name_required if {
-    result := violation_name_required with input as image
-    result[_].details.name == "name_label_required"
-    result[_].msg == "The required 'name' label is missing!"
+	result := violation_name_required with input as image
+	result[_].details.name == "name_label_required"
+	result[_].msg == "The required 'name' label is missing!"
 }
 
 test_violation_com_redhat_component_required if {
-    result := violation_com_redhat_component_required with input as image
-    result[_].details.name == "com_redhat_component_label_required!"
-    result[_].msg == "The required 'com.redhat.component' label is missing"
+	result := violation_com_redhat_component_required with input as image
+	result[_].details.name == "com_redhat_component_label_required!"
+	result[_].msg == "The required 'com.redhat.component' label is missing"
 }
 
 test_violation_version_required if {
-    result := violation_version_required with input as image
-    result[_].details.name == "version_label_required"
-    result[_].msg == "The required 'version' label is missing!"
+	result := violation_version_required with input as image
+	result[_].details.name == "version_label_required"
+	result[_].msg == "The required 'version' label is missing!"
 }
 
 test_violation_description_required if {
-    result := violation_description_required with input as image
-    result[_].details.name == "description_label_required"
-    result[_].msg == "The required 'description' label is missing!"
+	result := violation_description_required with input as image
+	result[_].details.name == "description_label_required"
+	result[_].msg == "The required 'description' label is missing!"
 }
 
 test_violation_io_k8s_description_required if {
-    result := violation_io_k8s_description_required with input as image
-    result[_].details.name == "io_k8s_description_label_required"
-    result[_].msg == "The required 'io.k8s.description' label is missing!"
+	result := violation_io_k8s_description_required with input as image
+	result[_].details.name == "io_k8s_description_label_required"
+	result[_].msg == "The required 'io.k8s.description' label is missing!"
 }
 
 test_violation_vcs_ref_required if {
-    result := violation_vcs_ref_required with input as image
-    result[_].details.name == "vcs_ref_label_required"
-    result[_].msg == "The required 'vcs-ref' label is missing!"
+	result := violation_vcs_ref_required with input as image
+	result[_].details.name == "vcs_ref_label_required"
+	result[_].msg == "The required 'vcs-ref' label is missing!"
 }
 
 test_violation_vcs_type_required if {
-    result := violation_vcs_type_required with input as image
-    result[_].details.name == "vcs_type_label_required"
-    result[_].msg == "The required 'vcs-type' label is missing!"
+	result := violation_vcs_type_required with input as image
+	result[_].details.name == "vcs_type_label_required"
+	result[_].msg == "The required 'vcs-type' label is missing!"
 }
 
 test_violation_architecture_required if {
-    result := violation_architecture_required with input as image
-    result[_].details.name == "architecture_label_required"
-    result[_].msg == "The required 'architecture' label is missing!"
+	result := violation_architecture_required with input as image
+	result[_].details.name == "architecture_label_required"
+	result[_].msg == "The required 'architecture' label is missing!"
 }
 
 test_violation_vendor_required if {
-    result := violation_vendor_required with input as image
-    result[_].details.name == "vendor_label_required"
-    result[_].msg == "The required 'vendor' label is missing!"
+	result := violation_vendor_required with input as image
+	result[_].details.name == "vendor_label_required"
+	result[_].msg == "The required 'vendor' label is missing!"
 }
 
 test_violation_release_required if {
-    result := violation_release_required with input as image
-    result[_].details.name == "release_label_required"
-    result[_].msg == "The required 'release' label is missing!"
+	result := violation_release_required with input as image
+	result[_].details.name == "release_label_required"
+	result[_].msg == "The required 'release' label is missing!"
 }
 
 test_violation_url_required if {
-    result := violation_url_required with input as image
-    result[_].details.name == "url_label_required"
-    result[_].msg == "The required 'url' label is missing!"
+	result := violation_url_required with input as image
+	result[_].details.name == "url_label_required"
+	result[_].msg == "The required 'url' label is missing!"
 }
 
 test_violation_build_date_required if {
-    result := violation_build_date_required with input as image
-    result[_].details.name == "build_date_label_required"
-    result[_].msg == "The required 'build-date' label is missing!"
+	result := violation_build_date_required with input as image
+	result[_].details.name == "build_date_label_required"
+	result[_].msg == "The required 'build-date' label is missing!"
 }
 
 test_violation_distribution_scope_required if {
-    result := violation_distribution_scope_required with input as image
-    result[_].details.name == "distribution_scope_label_required"
-    result[_].msg == "The required 'distribution-scope' label is missing!"
+	result := violation_distribution_scope_required with input as image
+	result[_].details.name == "distribution_scope_label_required"
+	result[_].msg == "The required 'distribution-scope' label is missing!"
 }

--- a/unittests/test_repository/deprecated-image_test.rego
+++ b/unittests/test_repository/deprecated-image_test.rego
@@ -2,11 +2,11 @@ package required_checks
 
 import future.keywords.if
 
-import data.repository as repository
+import data.repository
 
 test_violation_image_repository_deprecated if {
-    result := violation_image_repository_deprecated with input as repository
-    result[_].details.name == "image_repository_deprecated"
-    result[_].msg == "The container image shouldn't be built from a repository that is marked as 'Deprecated' in Red Hat Catalog."
-    result[_].details.url == "https://redhat-connect.gitbook.io/catalog-help/container-images/container-image-details/container-image-release-categories"
+	result := violation_image_repository_deprecated with input as repository
+	result[_].details.name == "image_repository_deprecated"
+	result[_].msg == "The container image shouldn't be built from a repository that is marked as 'Deprecated' in Red Hat Catalog."
+	result[_].details.url == "https://redhat-connect.gitbook.io/catalog-help/container-images/container-image-details/container-image-release-categories"
 }

--- a/unittests/test_rhtpa/vulnerabilities-check_test.rego
+++ b/unittests/test_rhtpa/vulnerabilities-check_test.rego
@@ -1,74 +1,75 @@
 package required_checks
 
-import data.rhtpa as rhtpa
 import data.curated_spdx_valid as curated
+import data.rhtpa
 import future.keywords.if
 
 test_warn_rhtpa_critical_vulnerabilities if {
-    result := warn_rhtpa_critical_vulnerabilities with input as rhtpa
-    count(result) == 1
-    result[0].details.name == "rhtpa_critical_vulnerabilities"
-    result[0].vulnerabilities_number == 1
-    contains(result[0].msg, "critical")
+	result := warn_rhtpa_critical_vulnerabilities with input as rhtpa
+	count(result) == 1
+	result[0].details.name == "rhtpa_critical_vulnerabilities"
+	result[0].vulnerabilities_number == 1
+	contains(result[0].msg, "critical")
 }
 
 test_warn_rhtpa_high_vulnerabilities if {
-    result := warn_rhtpa_high_vulnerabilities with input as rhtpa
-    count(result) == 1
-    result[0].details.name == "rhtpa_high_vulnerabilities"
-    # CVE-2024-0002 appears in both sources but is counted once (dedup)
-    result[0].vulnerabilities_number == 2
-    contains(result[0].msg, "high")
+	result := warn_rhtpa_high_vulnerabilities with input as rhtpa
+	count(result) == 1
+	result[0].details.name == "rhtpa_high_vulnerabilities"
+
+	# CVE-2024-0002 appears in both sources but is counted once (dedup)
+	result[0].vulnerabilities_number == 2
+	contains(result[0].msg, "high")
 }
 
 test_warn_rhtpa_medium_vulnerabilities if {
-    result := warn_rhtpa_medium_vulnerabilities with input as rhtpa
-    count(result) == 1
-    result[0].details.name == "rhtpa_medium_vulnerabilities"
-    result[0].vulnerabilities_number == 3
-    contains(result[0].msg, "medium")
+	result := warn_rhtpa_medium_vulnerabilities with input as rhtpa
+	count(result) == 1
+	result[0].details.name == "rhtpa_medium_vulnerabilities"
+	result[0].vulnerabilities_number == 3
+	contains(result[0].msg, "medium")
 }
 
 test_warn_rhtpa_low_vulnerabilities if {
-    result := warn_rhtpa_low_vulnerabilities with input as rhtpa
-    count(result) == 1
-    result[0].details.name == "rhtpa_low_vulnerabilities"
-    result[0].vulnerabilities_number == 2
-    contains(result[0].msg, "low")
+	result := warn_rhtpa_low_vulnerabilities with input as rhtpa
+	count(result) == 1
+	result[0].details.name == "rhtpa_low_vulnerabilities"
+	result[0].vulnerabilities_number == 2
+	contains(result[0].msg, "low")
 }
 
 test_warn_rhtpa_critical_vulnerabilities_realworld if {
-    result := warn_rhtpa_critical_vulnerabilities with input as curated
-    count(result) == 1
-    result[0].details.name == "rhtpa_critical_vulnerabilities"
-    result[0].vulnerabilities_number == 2
+	result := warn_rhtpa_critical_vulnerabilities with input as curated
+	count(result) == 1
+	result[0].details.name == "rhtpa_critical_vulnerabilities"
+	result[0].vulnerabilities_number == 2
 }
 
 test_warn_rhtpa_high_vulnerabilities_realworld if {
-    result := warn_rhtpa_high_vulnerabilities with input as curated
-    count(result) == 1
-    result[0].details.name == "rhtpa_high_vulnerabilities"
-    result[0].vulnerabilities_number == 6
+	result := warn_rhtpa_high_vulnerabilities with input as curated
+	count(result) == 1
+	result[0].details.name == "rhtpa_high_vulnerabilities"
+	result[0].vulnerabilities_number == 6
 }
 
 test_warn_rhtpa_medium_vulnerabilities_realworld if {
-    result := warn_rhtpa_medium_vulnerabilities with input as curated
-    count(result) == 1
-    result[0].details.name == "rhtpa_medium_vulnerabilities"
-    result[0].vulnerabilities_number == 3
+	result := warn_rhtpa_medium_vulnerabilities with input as curated
+	count(result) == 1
+	result[0].details.name == "rhtpa_medium_vulnerabilities"
+	result[0].vulnerabilities_number == 3
 }
 
 test_warn_rhtpa_low_vulnerabilities_realworld if {
-    result := warn_rhtpa_low_vulnerabilities with input as curated
-    count(result) == 1
-    result[0].details.name == "rhtpa_low_vulnerabilities"
-    result[0].vulnerabilities_number == 2
+	result := warn_rhtpa_low_vulnerabilities with input as curated
+	count(result) == 1
+	result[0].details.name == "rhtpa_low_vulnerabilities"
+	result[0].vulnerabilities_number == 2
 }
 
 test_warn_rhtpa_no_vulnerabilities if {
-    empty := {"providers": {"rhtpa": {"sources": {}}}}
-    warn_rhtpa_critical_vulnerabilities == [] with input as empty
-    warn_rhtpa_high_vulnerabilities == [] with input as empty
-    warn_rhtpa_medium_vulnerabilities == [] with input as empty
-    warn_rhtpa_low_vulnerabilities == [] with input as empty
+	empty := {"providers": {"rhtpa": {"sources": {}}}}
+	warn_rhtpa_critical_vulnerabilities == [] with input as empty
+	warn_rhtpa_high_vulnerabilities == [] with input as empty
+	warn_rhtpa_medium_vulnerabilities == [] with input as empty
+	warn_rhtpa_low_vulnerabilities == [] with input as empty
 }

--- a/unittests/test_roxtl/vulnerabilities-check_test.rego
+++ b/unittests/test_roxtl/vulnerabilities-check_test.rego
@@ -4,64 +4,64 @@ import data.roxctl_new as roxctl
 import future.keywords.if
 
 test_warn_critical_vulnerabilities if {
-    result := warn_roxctl_critical_vulnerabilities with input as roxctl
-    count(result) > 0
-    result[_].details.name == "roxctl_critical_vulnerabilities"
-    result[_].msg == "Found components with critical vulnerabilities that have available fixes. Consider updating to a newer version of those components."
+	result := warn_roxctl_critical_vulnerabilities with input as roxctl
+	count(result) > 0
+	result[_].details.name == "roxctl_critical_vulnerabilities"
+	result[_].msg == "Found components with critical vulnerabilities that have available fixes. Consider updating to a newer version of those components."
 }
 
 test_warn_unpatched_critical_vulnerabilities if {
-    result := warn_roxctl_unpatched_critical_vulnerabilities with input as roxctl
-    count(result) > 0
-    result[_].details.name == "roxctl_unpatched_critical_vulnerabilities"
-    result[_].msg == "Found components with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
+	result := warn_roxctl_unpatched_critical_vulnerabilities with input as roxctl
+	count(result) > 0
+	result[_].details.name == "roxctl_unpatched_critical_vulnerabilities"
+	result[_].msg == "Found components with unpatched critical vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
 test_warn_high_vulnerabilities if {
-    result := warn_roxctl_high_vulnerabilities with input as roxctl
-    count(result) > 0
-    result[_].details.name == "roxctl_high_vulnerabilities"
-    result[_].msg == "Found components with high vulnerabilities that have available fixes. Consider updating to a newer version of those components."
+	result := warn_roxctl_high_vulnerabilities with input as roxctl
+	count(result) > 0
+	result[_].details.name == "roxctl_high_vulnerabilities"
+	result[_].msg == "Found components with high vulnerabilities that have available fixes. Consider updating to a newer version of those components."
 }
 
 test_warn_unpatched_high_vulnerabilities if {
-    result := warn_roxctl_unpatched_high_vulnerabilities with input as roxctl
-    count(result) > 0
-    result[_].details.name == "roxctl_unpatched_high_vulnerabilities"
-    result[_].msg == "Found components with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."    
+	result := warn_roxctl_unpatched_high_vulnerabilities with input as roxctl
+	count(result) > 0
+	result[_].details.name == "roxctl_unpatched_high_vulnerabilities"
+	result[_].msg == "Found components with unpatched high vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
 test_warn_medium_vulnerabilities if {
-    result := warn_roxctl_medium_vulnerabilities with input as roxctl
-    count(result) > 0
-    result[_].details.name == "roxctl_medium_vulnerabilities"
-    result[_].msg == "Found components with medium vulnerabilities that have available fixes. Consider updating to a newer version of those components."
+	result := warn_roxctl_medium_vulnerabilities with input as roxctl
+	count(result) > 0
+	result[_].details.name == "roxctl_medium_vulnerabilities"
+	result[_].msg == "Found components with medium vulnerabilities that have available fixes. Consider updating to a newer version of those components."
 }
 
 test_warn_unpatched_medium_vulnerabilities if {
-    result := warn_roxctl_unpatched_medium_vulnerabilities with input as roxctl
-    count(result) > 0
-    result[_].details.name == "roxctl_unpatched_medium_vulnerabilities"
-    result[_].msg == "Found components with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."    
+	result := warn_roxctl_unpatched_medium_vulnerabilities with input as roxctl
+	count(result) > 0
+	result[_].details.name == "roxctl_unpatched_medium_vulnerabilities"
+	result[_].msg == "Found components with unpatched medium vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
 test_warn_low_vulnerabilities if {
-    result := warn_roxctl_low_vulnerabilities with input as roxctl
-    count(result) > 0
-    result[_].details.name == "roxctl_low_vulnerabilities"
-    result[_].msg == "Found components with low vulnerabilities that have available fixes. Consider updating to a newer version of those components."
+	result := warn_roxctl_low_vulnerabilities with input as roxctl
+	count(result) > 0
+	result[_].details.name == "roxctl_low_vulnerabilities"
+	result[_].msg == "Found components with low vulnerabilities that have available fixes. Consider updating to a newer version of those components."
 }
 
 test_warn_unpatched_low_vulnerabilities if {
-    result := warn_roxctl_unpatched_low_vulnerabilities with input as roxctl
-    count(result) > 0
-    result[_].details.name == "roxctl_unpatched_low_vulnerabilities"
-    result[_].msg == "Found components with unpatched low vulnerabilities. These vulnerabilities don't have a known fix at this time."    
+	result := warn_roxctl_unpatched_low_vulnerabilities with input as roxctl
+	count(result) > 0
+	result[_].details.name == "roxctl_unpatched_low_vulnerabilities"
+	result[_].msg == "Found components with unpatched low vulnerabilities. These vulnerabilities don't have a known fix at this time."
 }
 
-test_discrepancies_for_cve if{
-    result := discrepancies_for_cves with input as roxctl
-    count(result) > 0
-    result[_].details.name == "discrepancies"
-    result[_].msg == "Found cves with discrepancies."    
+test_discrepancies_for_cve if {
+	result := discrepancies_for_cves with input as roxctl
+	count(result) > 0
+	result[_].details.name == "discrepancies"
+	result[_].msg == "Found cves with discrepancies."
 }

--- a/unittests/test_rpm_manifest/unsigned-rpm_test.rego
+++ b/unittests/test_rpm_manifest/unsigned-rpm_test.rego
@@ -2,10 +2,10 @@ package required_checks
 
 import future.keywords.if
 
-import data.rpm_manifest as rpm_manifest
+import data.rpm_manifest
 
 test_violation_image_unsigned_rpms if {
-    result := violation_image_unsigned_rpms with input as rpm_manifest
-    result[_].details.name == "image_unsigned_rpms"
-    result[_].msg == "All RPMs found on the image must be signed. Found following unsigned rpms(nvra): perl-File-Path-2.09-2.el7.noarch"
+	result := violation_image_unsigned_rpms with input as rpm_manifest
+	result[_].details.name == "image_unsigned_rpms"
+	result[_].msg == "All RPMs found on the image must be signed. Found following unsigned rpms(nvra): perl-File-Path-2.09-2.el7.noarch"
 }


### PR DESCRIPTION

**Summary**

  Audit and enforce lint configuration for the konflux-test repository per STONEINTG-1666.

  **Changes**

  - Add .shellcheckrc and .hadolint.yaml config files, replacing inline rules scattered in the CI workflow
  - Enforce opa fmt canonical formatting across all Rego files and add a CI check to prevent drift
  - Add Regal (OPA/Rego linter) with a tuned .regal/config.yaml for conftest-style policies, plus minor lint fixes (redundant imports, raw regex string)

  What was already in place

  - yamllint, ShellCheck, Hadolint, and gitlint were running in CI but ShellCheck and Hadolint lacked dedicated config files

  What's new

  - .shellcheckrc — declares shell=bash (replaces SHELLCHECK_OPTS env var)
  - .hadolint.yaml — centralizes ignored rules and trusted registries
  - opa fmt CI gate — fails PRs with unformatted Rego
  - .regal/config.yaml + CI gate — 

more info : [STONEINTG-1686](https://redhat.atlassian.net/browse/STONEINTG-1686)

[STONEINTG-1686]: https://redhat.atlassian.net/browse/STONEINTG-1686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ