### PR TITLE
fix(STONEINTG-1708): parse_picklescan_output handles zero findings

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -2012,7 +2012,7 @@ parse_picklescan_output() {
 
   local infected_files_json
   infected_files_json=$(printf '%s\n' "$hits_section" | \
-    grep ' FOUND$' | \
+    { grep ' FOUND$' || [[ $? -eq 1 ]]; } | \
     jq -Rs '
       [ split("\n")[] | select(length > 0) |
         . as $line |
@@ -2023,7 +2023,7 @@ parse_picklescan_output() {
 
   local summary_json
   summary_json=$(printf '%s\n' "$summary_section" | \
-    grep -E '^[[:space:]]*[A-Za-z ]+:[[:space:]]*[0-9]+[[:space:]]*$' | \
+    { grep -E '^[[:space:]]*[A-Za-z ]+:[[:space:]]*[0-9]+[[:space:]]*$' || [[ $? -eq 1 ]]; } | \
     jq -Rs '
       [ split("\n")[] | select(length > 0) |
         split(": ") |

--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -2228,7 +2228,7 @@ Scanned files: 10
 Infected files: 2
 Dangerous globals: 2"
 
-    run parse_picklescan_output "$SCAN_OUTPUT"
+    run bash -c 'set -euo pipefail; source test/utils.sh; parse_picklescan_output "$1"' _ "$SCAN_OUTPUT"
 
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | jq -r '.infected_files["file1.pkl"]')" = "global import 'os.system' FOUND" ]
@@ -2244,7 +2244,7 @@ Scanned files: 5
 Infected files: 0
 Dangerous globals: 0"
 
-    run parse_picklescan_output "$SCAN_OUTPUT"
+    run bash -c 'set -euo pipefail; source test/utils.sh; parse_picklescan_output "$1"' _ "$SCAN_OUTPUT"
 
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | jq -r '.infected_files')" = "{}" ]


### PR DESCRIPTION
* Update parse_picklescan_output util function so that when no lines match FOUND$, it sets infected_files to {} instead of failing on grep’s exit code
* The existing unit tests already covered the use case, but did not use pipefail when executing, hence the issue being missed

Signed-off-by: dirgim <kpavic@redhat.com>