### PR TITLE
fix: update check-payload to 0.3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1783931515 as check-payload-
 
 #check-payload
 WORKDIR /opt/app-root/src
-ARG CHECK_PAYLOAD_VERSION=0.3.16
+ARG CHECK_PAYLOAD_VERSION=0.3.17
 
 RUN tar -xzf /cachi2/output/deps/generic/check-payload-${CHECK_PAYLOAD_VERSION}.tar.gz &&  cd check-payload-${CHECK_PAYLOAD_VERSION} && \
     CGO_ENABLED=0 go build -ldflags="-X main.Commit=${CHECK_PAYLOAD_VERSION}" -o /opt/app-root/src/check-payload-binary && \

--- a/artifacts.lock.yaml
+++ b/artifacts.lock.yaml
@@ -2,9 +2,9 @@
 metadata: 
   version: "1.0"
 artifacts:
-  - download_url: "https://github.com/openshift/check-payload/archive/refs/tags/0.3.16.tar.gz"
-    checksum: "sha256:e05295944129ccd3bcc3b6c7179c8c6b485caff41fa51456325eb28bbd4a0ab3"
-    filename: "check-payload-0.3.16.tar.gz"
+  - download_url: "https://github.com/openshift/check-payload/archive/refs/tags/0.3.17.tar.gz"
+    checksum: "sha256:9d554d96216183a1a6959760c400cc252b6074596ec0d54006e8d2d522137e23"
+    filename: "check-payload-0.3.17.tar.gz"
   - download_url: "https://github.com/CycloneDX/sbom-utility/releases/download/v0.12.0/sbom-utility-v0.12.0-linux-amd64.tar.gz"
     checksum: "sha256:762072a297f499691d59eeb3405aa873b6e71ea8f18d7db496511e584b0f5bb1"
     filename: "sbom-utility.tar.gz"


### PR DESCRIPTION
## Summary
- Bump `CHECK_PAYLOAD_VERSION` and `artifacts.lock.yaml` to openshift/check-payload **0.3.17**
- Brings RHAIENG-6078 codeserver seccomp exception into konflux-test for FIPS operator scanning

## Test plan
- [ ] Konflux hermetic build passes (Cachi2 prefetches new tarball)
- [ ] Release konflux-test patch after merge; propagate to konflux-operator-tasks FIPS tasks


Made with [Cursor](https://cursor.com)